### PR TITLE
docs: update GRPCClientInterceptor deprecation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ FilterMethodsFunc is the default implementation of Filter function
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
 ```
 
-Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by otelgrpc.NewClientHandler stats handler configured at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
+Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by the native grpc stats/opentelemetry package configured at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
 
 <a name="HystrixClientInterceptor"></a>
 ## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L644>)

--- a/README.md
+++ b/README.md
@@ -218,16 +218,16 @@ func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
 FilterMethodsFunc is the default implementation of Filter function
 
 <a name="GRPCClientInterceptor"></a>
-## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L630>)
+## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L631>)
 
 ```go
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
 ```
 
-Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by the native grpc stats/opentelemetry package configured at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
+Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by google.golang.org/grpc/stats/opentelemetry, configured via opentelemetry.DialOption\(\) at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
 
 <a name="HystrixClientInterceptor"></a>
-## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L644>)
+## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L645>)
 
 ```go
 func HystrixClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientInterceptor
@@ -240,7 +240,7 @@ Note: This interceptor wraps github.com/afex/hystrix\-go which has been unmainta
 The interceptor applies provided default and per\-call client options to configure Hystrix behavior \(for example the command name, disabled flag, excluded errors, and excluded gRPC status codes\). If Hystrix is disabled via options, the RPC is invoked directly. If the underlying RPC returns an error that matches any configured excluded error or whose gRPC status code matches any configured excluded code, Hystrix fallback is skipped and the RPC error is returned. Panics raised during the RPC invocation are captured and reported to the notifier before being converted into an error. If the RPC itself returns an error, that error is returned; otherwise any error produced by Hystrix is returned.
 
 <a name="NRHttpTracer"></a>
-## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L737>)
+## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L738>)
 
 ```go
 func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
@@ -312,7 +312,7 @@ func ResponseTimeLoggingInterceptor(ff FilterFunc) grpc.UnaryServerInterceptor
 ResponseTimeLoggingInterceptor logs response time for each request on server
 
 <a name="ResponseTimeLoggingStreamInterceptor"></a>
-## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L700>)
+## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L701>)
 
 ```go
 func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor
@@ -330,7 +330,7 @@ func ServerErrorInterceptor() grpc.UnaryServerInterceptor
 ServerErrorInterceptor intercepts all server actions and reports them to error notifier
 
 <a name="ServerErrorStreamInterceptor"></a>
-## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L720>)
+## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L721>)
 
 ```go
 func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
@@ -411,7 +411,7 @@ func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
 SetServerMetricsOptions appends gRPC server metrics options \(histogram, labels, namespace, etc.\). Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="TraceIdInterceptor"></a>
-## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L759>)
+## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L760>)
 
 ```go
 func TraceIdInterceptor() grpc.UnaryServerInterceptor

--- a/interceptors.go
+++ b/interceptors.go
@@ -625,8 +625,9 @@ func NewRelicClientInterceptor() grpc.UnaryClientInterceptor {
 }
 
 // Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled
-// by the native grpc stats/opentelemetry package configured at the client level.
-// This function is retained for backwards compatibility but returns a no-op interceptor.
+// by google.golang.org/grpc/stats/opentelemetry, configured via opentelemetry.DialOption()
+// at the client level. This function is retained for backwards compatibility but returns
+// a no-op interceptor.
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		return invoker(ctx, method, req, reply, cc, opts...)

--- a/interceptors.go
+++ b/interceptors.go
@@ -625,7 +625,7 @@ func NewRelicClientInterceptor() grpc.UnaryClientInterceptor {
 }
 
 // Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled
-// by otelgrpc.NewClientHandler stats handler configured at the client level.
+// by the native grpc stats/opentelemetry package configured at the client level.
 // This function is retained for backwards compatibility but returns a no-op interceptor.
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {


### PR DESCRIPTION
## Summary
- Update deprecated `GRPCClientInterceptor` doc comment to reference the native `grpc stats/opentelemetry` package instead of the contrib `otelgrpc` package

Companion to core migration in go-coldbrew/core (roadmap item 8.1).

## Test plan
- [ ] `make build && make test && make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deprecation notes regarding gRPC client tracing mechanisms, specifying that tracing is handled through native gRPC stats and OpenTelemetry implementations configured at the client level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->