### PR TITLE
feat: add DefaultTimeoutInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ DefaultStreamInterceptors are the set of default interceptors that should be app
 func DefaultTimeoutInterceptor() grpc.UnaryServerInterceptor
 ```
 
-DefaultTimeoutInterceptor returns a unary server interceptor that applies a default deadline to incoming requests that have no deadline set. If the incoming context already has a deadline \(regardless of duration\), it is left unchanged. When defaultTimeout is 0, the interceptor is a no\-op pass\-through.
+DefaultTimeoutInterceptor returns a unary server interceptor that applies a default deadline to incoming requests that have no deadline set. If the incoming context already has a deadline \(regardless of duration\), it is left unchanged. When defaultTimeout is \<= 0, the interceptor is a no\-op pass\-through.
 
 <a name="DoHTTPtoGRPC"></a>
 ## func [DoHTTPtoGRPC](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L408>)
@@ -365,7 +365,7 @@ SetClientMetricsOptions appends gRPC client metrics options. Must be called duri
 func SetDefaultTimeout(d time.Duration)
 ```
 
-SetDefaultTimeout sets the default timeout applied to incoming unary RPCs that arrive without a deadline. When set to 0, the timeout interceptor is disabled \(pass\-through\). Default is 60s. Must be called during initialization, before the server starts. Not safe for concurrent use.
+SetDefaultTimeout sets the default timeout applied to incoming unary RPCs that arrive without a deadline. When set to \<= 0, the timeout interceptor is disabled \(pass\-through\). Default is 60s. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetDisableProtoValidate"></a>
 ## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L258>)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Interceptor configuration functions \(AddUnaryServerInterceptor, SetFilterFunc, 
 - [func DefaultClientStreamInterceptors\(defaultOpts ...any\) \[\]grpc.StreamClientInterceptor](<#DefaultClientStreamInterceptors>)
 - [func DefaultInterceptors\(\) \[\]grpc.UnaryServerInterceptor](<#DefaultInterceptors>)
 - [func DefaultStreamInterceptors\(\) \[\]grpc.StreamServerInterceptor](<#DefaultStreamInterceptors>)
+- [func DefaultTimeoutInterceptor\(\) grpc.UnaryServerInterceptor](<#DefaultTimeoutInterceptor>)
 - [func DoHTTPtoGRPC\(ctx context.Context, svr any, handler func\(ctx context.Context, req any\) \(any, error\), in any\) \(any, error\)](<#DoHTTPtoGRPC>)
 - [func FilterMethodsFunc\(ctx context.Context, fullMethodName string\) bool](<#FilterMethodsFunc>)
 - [func GRPCClientInterceptor\(\_ ...any\) grpc.UnaryClientInterceptor](<#GRPCClientInterceptor>)
@@ -48,6 +49,7 @@ Interceptor configuration functions \(AddUnaryServerInterceptor, SetFilterFunc, 
 - [func ServerErrorInterceptor\(\) grpc.UnaryServerInterceptor](<#ServerErrorInterceptor>)
 - [func ServerErrorStreamInterceptor\(\) grpc.StreamServerInterceptor](<#ServerErrorStreamInterceptor>)
 - [func SetClientMetricsOptions\(opts ...grpcprom.ClientMetricsOption\)](<#SetClientMetricsOptions>)
+- [func SetDefaultTimeout\(d time.Duration\)](<#SetDefaultTimeout>)
 - [func SetDisableProtoValidate\(disable bool\)](<#SetDisableProtoValidate>)
 - [func SetFilterFunc\(ctx context.Context, ff FilterFunc\)](<#SetFilterFunc>)
 - [func SetFilterMethods\(ctx context.Context, methods \[\]string\)](<#SetFilterMethods>)
@@ -84,7 +86,7 @@ var (
 ```
 
 <a name="AddStreamClientInterceptor"></a>
-## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L217>)
+## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L226>)
 
 ```go
 func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInterceptor)
@@ -93,7 +95,7 @@ func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInter
 AddStreamClientInterceptor adds a client stream interceptor to default client stream interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddStreamServerInterceptor"></a>
-## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L198>)
+## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L207>)
 
 ```go
 func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInterceptor)
@@ -102,7 +104,7 @@ func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInter
 AddStreamServerInterceptor adds a server interceptor to default server interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="AddUnaryClientInterceptor"></a>
-## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L211>)
+## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L220>)
 
 ```go
 func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterceptor)
@@ -111,7 +113,7 @@ func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterce
 AddUnaryClientInterceptor adds a client interceptor to default client interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddUnaryServerInterceptor"></a>
-## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L192>)
+## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L201>)
 
 ```go
 func AddUnaryServerInterceptor(ctx context.Context, i ...grpc.UnaryServerInterceptor)
@@ -120,7 +122,7 @@ func AddUnaryServerInterceptor(ctx context.Context, i ...grpc.UnaryServerInterce
 AddUnaryServerInterceptor adds a server interceptor to default server interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="DebugLoggingInterceptor"></a>
-## func [DebugLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L509>)
+## func [DebugLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L519>)
 
 ```go
 func DebugLoggingInterceptor() grpc.UnaryServerInterceptor
@@ -129,7 +131,7 @@ func DebugLoggingInterceptor() grpc.UnaryServerInterceptor
 DebugLoggingInterceptor is the interceptor that logs all request/response from a handler
 
 <a name="DefaultClientInterceptor"></a>
-## func [DefaultClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L499>)
+## func [DefaultClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L509>)
 
 ```go
 func DefaultClientInterceptor(defaultOpts ...any) grpc.UnaryClientInterceptor
@@ -138,7 +140,7 @@ func DefaultClientInterceptor(defaultOpts ...any) grpc.UnaryClientInterceptor
 DefaultClientInterceptor are the set of default interceptors that should be applied to all client calls
 
 <a name="DefaultClientInterceptors"></a>
-## func [DefaultClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L437>)
+## func [DefaultClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L447>)
 
 ```go
 func DefaultClientInterceptors(defaultOpts ...any) []grpc.UnaryClientInterceptor
@@ -147,7 +149,7 @@ func DefaultClientInterceptors(defaultOpts ...any) []grpc.UnaryClientInterceptor
 DefaultClientInterceptors are the set of default interceptors that should be applied to all client calls
 
 <a name="DefaultClientStreamInterceptor"></a>
-## func [DefaultClientStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L504>)
+## func [DefaultClientStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L514>)
 
 ```go
 func DefaultClientStreamInterceptor(defaultOpts ...any) grpc.StreamClientInterceptor
@@ -156,7 +158,7 @@ func DefaultClientStreamInterceptor(defaultOpts ...any) grpc.StreamClientInterce
 DefaultClientStreamInterceptor are the set of default interceptors that should be applied to all stream client calls
 
 <a name="DefaultClientStreamInterceptors"></a>
-## func [DefaultClientStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L463>)
+## func [DefaultClientStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L473>)
 
 ```go
 func DefaultClientStreamInterceptors(defaultOpts ...any) []grpc.StreamClientInterceptor
@@ -165,7 +167,7 @@ func DefaultClientStreamInterceptors(defaultOpts ...any) []grpc.StreamClientInte
 DefaultClientStreamInterceptors are the set of default interceptors that should be applied to all stream client calls
 
 <a name="DefaultInterceptors"></a>
-## func [DefaultInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L413>)
+## func [DefaultInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L422>)
 
 ```go
 func DefaultInterceptors() []grpc.UnaryServerInterceptor
@@ -174,7 +176,7 @@ func DefaultInterceptors() []grpc.UnaryServerInterceptor
 DefaultInterceptors are the set of default interceptors that are applied to all coldbrew methods
 
 <a name="DefaultStreamInterceptors"></a>
-## func [DefaultStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L478>)
+## func [DefaultStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L488>)
 
 ```go
 func DefaultStreamInterceptors() []grpc.StreamServerInterceptor
@@ -182,8 +184,17 @@ func DefaultStreamInterceptors() []grpc.StreamServerInterceptor
 
 DefaultStreamInterceptors are the set of default interceptors that should be applied to all coldbrew streams
 
+<a name="DefaultTimeoutInterceptor"></a>
+## func [DefaultTimeoutInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L532>)
+
+```go
+func DefaultTimeoutInterceptor() grpc.UnaryServerInterceptor
+```
+
+DefaultTimeoutInterceptor returns a unary server interceptor that applies a default deadline to incoming requests that have no deadline set. If the incoming context already has a deadline \(regardless of duration\), it is left unchanged. When defaultTimeout is 0, the interceptor is a no\-op pass\-through.
+
 <a name="DoHTTPtoGRPC"></a>
-## func [DoHTTPtoGRPC](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L399>)
+## func [DoHTTPtoGRPC](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L408>)
 
 ```go
 func DoHTTPtoGRPC(ctx context.Context, svr any, handler func(ctx context.Context, req any) (any, error), in any) (any, error)
@@ -209,7 +220,7 @@ func (s *svc) echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResp
 ```
 
 <a name="FilterMethodsFunc"></a>
-## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L155>)
+## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L164>)
 
 ```go
 func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
@@ -218,7 +229,7 @@ func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
 FilterMethodsFunc is the default implementation of Filter function
 
 <a name="GRPCClientInterceptor"></a>
-## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L631>)
+## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L659>)
 
 ```go
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
@@ -227,7 +238,7 @@ func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
 Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by google.golang.org/grpc/stats/opentelemetry, configured via opentelemetry.DialOption\(\) at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
 
 <a name="HystrixClientInterceptor"></a>
-## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L645>)
+## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L673>)
 
 ```go
 func HystrixClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientInterceptor
@@ -240,7 +251,7 @@ Note: This interceptor wraps github.com/afex/hystrix\-go which has been unmainta
 The interceptor applies provided default and per\-call client options to configure Hystrix behavior \(for example the command name, disabled flag, excluded errors, and excluded gRPC status codes\). If Hystrix is disabled via options, the RPC is invoked directly. If the underlying RPC returns an error that matches any configured excluded error or whose gRPC status code matches any configured excluded code, Hystrix fallback is skipped and the RPC error is returned. Panics raised during the RPC invocation are captured and reported to the notifier before being converted into an error. If the RPC itself returns an error, that error is returned; otherwise any error produced by Hystrix is returned.
 
 <a name="NRHttpTracer"></a>
-## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L738>)
+## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L766>)
 
 ```go
 func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
@@ -249,7 +260,7 @@ func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 NRHttpTracer adds newrelic tracing to this http function
 
 <a name="NewRelicClientInterceptor"></a>
-## func [NewRelicClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L611>)
+## func [NewRelicClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L639>)
 
 ```go
 func NewRelicClientInterceptor() grpc.UnaryClientInterceptor
@@ -258,7 +269,7 @@ func NewRelicClientInterceptor() grpc.UnaryClientInterceptor
 NewRelicClientInterceptor intercepts all client actions and reports them to newrelic. When NewRelic app is nil \(no license key configured\), returns a pass\-through interceptor to avoid overhead.
 
 <a name="NewRelicInterceptor"></a>
-## func [NewRelicInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L552>)
+## func [NewRelicInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L580>)
 
 ```go
 func NewRelicInterceptor() grpc.UnaryServerInterceptor
@@ -267,7 +278,7 @@ func NewRelicInterceptor() grpc.UnaryServerInterceptor
 NewRelicInterceptor intercepts all server actions and reports them to newrelic. When NewRelic app is nil \(no license key configured\), returns a pass\-through interceptor to avoid overhead.
 
 <a name="OptionsInterceptor"></a>
-## func [OptionsInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L541>)
+## func [OptionsInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L569>)
 
 ```go
 func OptionsInterceptor() grpc.UnaryServerInterceptor
@@ -276,7 +287,7 @@ func OptionsInterceptor() grpc.UnaryServerInterceptor
 
 
 <a name="PanicRecoveryInterceptor"></a>
-## func [PanicRecoveryInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L586>)
+## func [PanicRecoveryInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L614>)
 
 ```go
 func PanicRecoveryInterceptor() grpc.UnaryServerInterceptor
@@ -285,7 +296,7 @@ func PanicRecoveryInterceptor() grpc.UnaryServerInterceptor
 
 
 <a name="ProtoValidateInterceptor"></a>
-## func [ProtoValidateInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L257>)
+## func [ProtoValidateInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L266>)
 
 ```go
 func ProtoValidateInterceptor() grpc.UnaryServerInterceptor
@@ -294,7 +305,7 @@ func ProtoValidateInterceptor() grpc.UnaryServerInterceptor
 ProtoValidateInterceptor returns a unary server interceptor that validates incoming messages using protovalidate annotations. Returns InvalidArgument on validation failure. Uses GlobalValidator by default; if custom options are set via SetProtoValidateOptions, creates a new validator with those options.
 
 <a name="ProtoValidateStreamInterceptor"></a>
-## func [ProtoValidateStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L263>)
+## func [ProtoValidateStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L272>)
 
 ```go
 func ProtoValidateStreamInterceptor() grpc.StreamServerInterceptor
@@ -303,7 +314,7 @@ func ProtoValidateStreamInterceptor() grpc.StreamServerInterceptor
 ProtoValidateStreamInterceptor returns a stream server interceptor that validates incoming messages using protovalidate annotations.
 
 <a name="ResponseTimeLoggingInterceptor"></a>
-## func [ResponseTimeLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L519>)
+## func [ResponseTimeLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L547>)
 
 ```go
 func ResponseTimeLoggingInterceptor(ff FilterFunc) grpc.UnaryServerInterceptor
@@ -312,7 +323,7 @@ func ResponseTimeLoggingInterceptor(ff FilterFunc) grpc.UnaryServerInterceptor
 ResponseTimeLoggingInterceptor logs response time for each request on server
 
 <a name="ResponseTimeLoggingStreamInterceptor"></a>
-## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L701>)
+## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L729>)
 
 ```go
 func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor
@@ -321,7 +332,7 @@ func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor
 ResponseTimeLoggingStreamInterceptor logs response time for stream RPCs.
 
 <a name="ServerErrorInterceptor"></a>
-## func [ServerErrorInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L570>)
+## func [ServerErrorInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L598>)
 
 ```go
 func ServerErrorInterceptor() grpc.UnaryServerInterceptor
@@ -330,7 +341,7 @@ func ServerErrorInterceptor() grpc.UnaryServerInterceptor
 ServerErrorInterceptor intercepts all server actions and reports them to error notifier
 
 <a name="ServerErrorStreamInterceptor"></a>
-## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L721>)
+## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L749>)
 
 ```go
 func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
@@ -339,7 +350,7 @@ func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
 ServerErrorStreamInterceptor intercepts server errors for stream RPCs and reports them to the error notifier.
 
 <a name="SetClientMetricsOptions"></a>
-## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L236>)
+## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L245>)
 
 ```go
 func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
@@ -347,8 +358,17 @@ func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
 
 SetClientMetricsOptions appends gRPC client metrics options. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
+<a name="SetDefaultTimeout"></a>
+## func [SetDefaultTimeout](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L91>)
+
+```go
+func SetDefaultTimeout(d time.Duration)
+```
+
+SetDefaultTimeout sets the default timeout applied to incoming unary RPCs that arrive without a deadline. When set to 0, the timeout interceptor is disabled \(pass\-through\). Default is 60s. Must be called during initialization, before the server starts. Not safe for concurrent use.
+
 <a name="SetDisableProtoValidate"></a>
-## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L249>)
+## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L258>)
 
 ```go
 func SetDisableProtoValidate(disable bool)
@@ -357,7 +377,7 @@ func SetDisableProtoValidate(disable bool)
 SetDisableProtoValidate disables the protovalidate interceptor in the default chain. Must be called during init\(\) — not safe for concurrent use.
 
 <a name="SetFilterFunc"></a>
-## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L184>)
+## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L193>)
 
 ```go
 func SetFilterFunc(ctx context.Context, ff FilterFunc)
@@ -366,7 +386,7 @@ func SetFilterFunc(ctx context.Context, ff FilterFunc)
 SetFilterFunc sets the default filter function to be used by interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetFilterMethods"></a>
-## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L135>)
+## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L144>)
 
 ```go
 func SetFilterMethods(ctx context.Context, methods []string)
@@ -375,7 +395,7 @@ func SetFilterMethods(ctx context.Context, methods []string)
 SetFilterMethods sets the list of method substrings to exclude from tracing/logging. It rebuilds the internal cache. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetProtoValidateOptions"></a>
-## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L243>)
+## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L252>)
 
 ```go
 func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption)
@@ -384,7 +404,7 @@ func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption)
 SetProtoValidateOptions configures custom protovalidate options \(e.g., custom constraints\). Must be called during init\(\) — not safe for concurrent use. Follows ColdBrew's init\-only config pattern.
 
 <a name="SetResponseTimeLogErrorOnly"></a>
-## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L82>)
+## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L83>)
 
 ```go
 func SetResponseTimeLogErrorOnly(errorOnly bool)
@@ -393,7 +413,7 @@ func SetResponseTimeLogErrorOnly(errorOnly bool)
 SetResponseTimeLogErrorOnly when set to true, only logs response time when the request returns an error. Successful requests are not logged. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetResponseTimeLogLevel"></a>
-## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L75>)
+## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L76>)
 
 ```go
 func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
@@ -402,7 +422,7 @@ func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
 SetResponseTimeLogLevel sets the log level for response time logging. Default is InfoLevel. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetServerMetricsOptions"></a>
-## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L230>)
+## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L239>)
 
 ```go
 func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
@@ -411,7 +431,7 @@ func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
 SetServerMetricsOptions appends gRPC server metrics options \(histogram, labels, namespace, etc.\). Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="TraceIdInterceptor"></a>
-## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L760>)
+## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L788>)
 
 ```go
 func TraceIdInterceptor() grpc.UnaryServerInterceptor
@@ -420,7 +440,7 @@ func TraceIdInterceptor() grpc.UnaryServerInterceptor
 TraceIdInterceptor allows injecting trace id from request objects
 
 <a name="UseColdBrewClientInterceptors"></a>
-## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L224>)
+## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L233>)
 
 ```go
 func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
@@ -429,7 +449,7 @@ func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
 UseColdBrewClientInterceptors allows enabling/disabling coldbrew client interceptors. When set to false, the coldbrew client interceptors will not be used. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="UseColdBrewServerInterceptors"></a>
-## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L205>)
+## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L214>)
 
 ```go
 func UseColdBrewServerInterceptors(ctx context.Context, flag bool)
@@ -438,7 +458,7 @@ func UseColdBrewServerInterceptors(ctx context.Context, flag bool)
 UseColdBrewServerInterceptors allows enabling/disabling coldbrew server interceptors. When set to false, the coldbrew server interceptors will not be used. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="FilterFunc"></a>
-## type [FilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L87>)
+## type [FilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/interceptors.go#L96>)
 
 If it returns false, the given request will not be traced.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-coldbrew/interceptors
 
-go 1.25.8
+go 1.25.9
 
 require (
 	buf.build/go/protovalidate v1.1.3

--- a/interceptors.go
+++ b/interceptors.go
@@ -60,6 +60,7 @@ var (
 	useCBClientInterceptors                = true
 	responseTimeLogLevel     loggers.Level = loggers.InfoLevel
 	responseTimeLogErrorOnly bool
+	defaultTimeout           time.Duration = 60 * time.Second // 0 disables
 	protoValidateOpts        []protovalidate.ValidatorOption
 	disableProtoValidate     bool
 	srvMetricsOpts           []grpcprom.ServerMetricsOption
@@ -81,6 +82,14 @@ func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level) {
 // Must be called during initialization, before the server starts. Not safe for concurrent use.
 func SetResponseTimeLogErrorOnly(errorOnly bool) {
 	responseTimeLogErrorOnly = errorOnly
+}
+
+// SetDefaultTimeout sets the default timeout applied to incoming unary RPCs
+// that arrive without a deadline. When set to 0, the timeout interceptor is
+// disabled (pass-through). Default is 60s.
+// Must be called during initialization, before the server starts. Not safe for concurrent use.
+func SetDefaultTimeout(d time.Duration) {
+	defaultTimeout = d
 }
 
 // If it returns false, the given request will not be traced.
@@ -417,6 +426,7 @@ func DefaultInterceptors() []grpc.UnaryServerInterceptor {
 	}
 	if useCBServerInterceptors {
 		ints = append(ints,
+			DefaultTimeoutInterceptor(),
 			ResponseTimeLoggingInterceptor(defaultFilterFunc),
 			TraceIdInterceptor(),
 		)
@@ -512,6 +522,24 @@ func DebugLoggingInterceptor() grpc.UnaryServerInterceptor {
 		resp, err := handler(ctx, req)
 		log.Debug(ctx, "method", info.FullMethod, "response", resp, "err", err)
 		return resp, err
+	}
+}
+
+// DefaultTimeoutInterceptor returns a unary server interceptor that applies a
+// default deadline to incoming requests that have no deadline set. If the
+// incoming context already has a deadline (regardless of duration), it is left
+// unchanged. When defaultTimeout is 0, the interceptor is a no-op pass-through.
+func DefaultTimeoutInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if defaultTimeout <= 0 {
+			return handler(ctx, req)
+		}
+		if _, ok := ctx.Deadline(); ok {
+			return handler(ctx, req)
+		}
+		ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+		return handler(ctx, req)
 	}
 }
 

--- a/interceptors.go
+++ b/interceptors.go
@@ -85,7 +85,7 @@ func SetResponseTimeLogErrorOnly(errorOnly bool) {
 }
 
 // SetDefaultTimeout sets the default timeout applied to incoming unary RPCs
-// that arrive without a deadline. When set to 0, the timeout interceptor is
+// that arrive without a deadline. When set to <= 0, the timeout interceptor is
 // disabled (pass-through). Default is 60s.
 // Must be called during initialization, before the server starts. Not safe for concurrent use.
 func SetDefaultTimeout(d time.Duration) {
@@ -528,7 +528,7 @@ func DebugLoggingInterceptor() grpc.UnaryServerInterceptor {
 // DefaultTimeoutInterceptor returns a unary server interceptor that applies a
 // default deadline to incoming requests that have no deadline set. If the
 // incoming context already has a deadline (regardless of duration), it is left
-// unchanged. When defaultTimeout is 0, the interceptor is a no-op pass-through.
+// unchanged. When defaultTimeout is <= 0, the interceptor is a no-op pass-through.
 func DefaultTimeoutInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if defaultTimeout <= 0 {

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-coldbrew/log/loggers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -42,6 +43,7 @@ func resetGlobals() {
 	useCBClientInterceptors = true
 	responseTimeLogErrorOnly = false
 	responseTimeLogLevel = loggers.InfoLevel
+	defaultTimeout = 60 * time.Second
 	httpToGRPCOnce = sync.Once{}
 	httpToGRPCInterceptor = nil
 }
@@ -1027,5 +1029,111 @@ func TestDoHTTPtoGRPC_InterceptorCaching(t *testing.T) {
 	}
 	if interceptor2Called {
 		t.Error("interceptor added after first DoHTTPtoGRPC call should not be in the cached chain")
+	}
+}
+
+func TestDefaultTimeoutInterceptor_AppliesTimeout(t *testing.T) {
+	defer resetGlobals()
+
+	interceptor := DefaultTimeoutInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	ctx := context.Background()
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected deadline to be set")
+		}
+		remaining := time.Until(deadline)
+		if remaining < 59*time.Second || remaining > 61*time.Second {
+			t.Fatalf("expected ~60s deadline, got %v", remaining)
+		}
+		return "ok", nil
+	}
+
+	resp, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "ok" {
+		t.Fatalf("expected 'ok', got %v", resp)
+	}
+}
+
+func TestDefaultTimeoutInterceptor_ExistingDeadline(t *testing.T) {
+	defer resetGlobals()
+
+	interceptor := DefaultTimeoutInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected deadline to be set")
+		}
+		remaining := time.Until(deadline)
+		if remaining > 6*time.Second {
+			t.Fatalf("deadline should be ~5s from caller, got %v", remaining)
+		}
+		return "ok", nil
+	}
+
+	_, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultTimeoutInterceptor_Disabled(t *testing.T) {
+	defer resetGlobals()
+
+	SetDefaultTimeout(0)
+	interceptor := DefaultTimeoutInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	ctx := context.Background()
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		if _, ok := ctx.Deadline(); ok {
+			t.Fatal("expected no deadline when timeout is disabled")
+		}
+		return "ok", nil
+	}
+
+	_, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultInterceptors_IncludesTimeout(t *testing.T) {
+	defer resetGlobals()
+
+	// Call the DefaultTimeoutInterceptor directly from the chain to verify it's wired in.
+	// The first CB interceptor (index 0 when no user interceptors) should be the timeout.
+	ints := DefaultInterceptors()
+	if len(ints) == 0 {
+		t.Fatal("expected at least one interceptor")
+	}
+
+	// The first interceptor should set a deadline on a bare context.
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	deadlineSet := false
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		if _, ok := ctx.Deadline(); ok {
+			deadlineSet = true
+		}
+		return "ok", nil
+	}
+
+	_, err := ints[0](ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deadlineSet {
+		t.Error("expected first CB interceptor (DefaultTimeoutInterceptor) to set a deadline")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `DefaultTimeoutInterceptor` — applies a 60s default deadline to incoming unary gRPC requests that arrive without one
- Requests with an existing deadline (shorter or longer) are left unchanged
- Inserted as first ColdBrew interceptor in the default chain, before `ResponseTimeLoggingInterceptor`
- `SetDefaultTimeout(d)` setter for programmatic config; `0` disables (pass-through)
- Protects both direct gRPC and HTTP gateway paths (gateway disables Hystrix and sets no deadline today)

## Test plan
- [x] `TestDefaultTimeoutInterceptor_AppliesTimeout` — no deadline → handler sees ~60s deadline
- [x] `TestDefaultTimeoutInterceptor_ExistingDeadline` — caller's deadline preserved
- [x] `TestDefaultTimeoutInterceptor_Disabled` — `SetDefaultTimeout(0)` → no deadline added
- [x] `TestDefaultInterceptors_IncludesTimeout` — first CB interceptor sets deadline
- [x] `make test` passes with `-race`
- [x] `make lint` clean (0 issues, no vulnerabilities)