### PR TITLE
fix: apply filterFunc in NRHttpTracer for non-empty pattern (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,13 +296,13 @@ Deprecated: HystrixClientInterceptor wraps the unmaintained hystrix\-go library.
 See [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for the replacement.
 
 <a name="NRHttpTracer"></a>
-## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/http.go#L61>)
+## func [NRHttpTracer](<https://github.com/go-coldbrew/interceptors/blob/main/http.go#L65>)
 
 ```go
 func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 ```
 
-NRHttpTracer adds newrelic tracing to this http function
+NRHttpTracer wraps an HTTP handler with New Relic tracing. The configured filterFunc \(see SetFilterFunc\) is consulted on every request: paths it rejects run the underlying handler without starting a New Relic transaction. When pattern is non\-empty, newrelic.WrapHandleFunc is used so its route\-level instrumentation stays intact for non\-filtered paths.
 
 <a name="NewRelicClientInterceptor"></a>
 ## func [NewRelicClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L78>)

--- a/http.go
+++ b/http.go
@@ -78,7 +78,6 @@ func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 		})
 	}
 	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// filter functions we do not need
 		if defaultConfig.filterFunc(r.Context(), r.URL.Path) {
 			txn := app.StartTransaction(r.Method + " " + r.URL.Path)
 			defer txn.End()

--- a/http.go
+++ b/http.go
@@ -57,14 +57,25 @@ func DoHTTPtoGRPC(ctx context.Context, svr any, handler func(ctx context.Context
 	return handler(ctx, in)
 }
 
-// NRHttpTracer adds newrelic tracing to this http function
+// NRHttpTracer wraps an HTTP handler with New Relic tracing. The configured
+// filterFunc (see SetFilterFunc) is consulted on every request: paths it
+// rejects run the underlying handler without starting a New Relic
+// transaction. When pattern is non-empty, newrelic.WrapHandleFunc is used so
+// its route-level instrumentation stays intact for non-filtered paths.
 func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc) {
 	app := nrutil.GetNewRelicApp()
 	if app == nil {
 		return pattern, h
 	}
 	if pattern != "" {
-		return newrelic.WrapHandleFunc(app, pattern, h)
+		wrappedPattern, wrappedHandler := newrelic.WrapHandleFunc(app, pattern, h)
+		return wrappedPattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if defaultConfig.filterFunc(context.Background(), r.URL.Path) {
+				wrappedHandler(w, r)
+				return
+			}
+			h(w, r)
+		})
 	}
 	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// filter functions we do not need

--- a/http.go
+++ b/http.go
@@ -70,7 +70,7 @@ func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 	if pattern != "" {
 		wrappedPattern, wrappedHandler := newrelic.WrapHandleFunc(app, pattern, h)
 		return wrappedPattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if defaultConfig.filterFunc(context.Background(), r.URL.Path) {
+			if defaultConfig.filterFunc(r.Context(), r.URL.Path) {
 				wrappedHandler(w, r)
 				return
 			}
@@ -79,7 +79,7 @@ func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 	}
 	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// filter functions we do not need
-		if defaultConfig.filterFunc(context.Background(), r.URL.Path) {
+		if defaultConfig.filterFunc(r.Context(), r.URL.Path) {
 			txn := app.StartTransaction(r.Method + " " + r.URL.Path)
 			defer txn.End()
 			w = txn.SetWebResponse(w)

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2231,7 +2232,7 @@ func TestNRHttpTracer_NilApp(t *testing.T) {
 		t.Errorf("pattern should be unchanged when NR app is nil; got %q", p)
 	}
 	// With no NR app, the function must return the original handler reference.
-	if fmt.Sprintf("%p", got) != fmt.Sprintf("%p", h) {
+	if reflect.ValueOf(got).Pointer() != reflect.ValueOf(h).Pointer() {
 		t.Error("expected original handler to be returned unchanged when NR app is nil")
 	}
 }

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14,8 +15,10 @@ import (
 	"github.com/go-coldbrew/errors/notifier"
 	"github.com/go-coldbrew/log"
 	"github.com/go-coldbrew/log/loggers"
+	nrutil "github.com/go-coldbrew/tracing/newrelic"
 	ratelimit_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	newrelic "github.com/newrelic/go-agent/v3/newrelic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcmd "google.golang.org/grpc/metadata"
@@ -2195,5 +2198,108 @@ func TestDefaultStreamInterceptors_UserInterceptorsOutermost(t *testing.T) {
 	})
 	if len(order) == 0 || order[0] != "user" {
 		t.Errorf("user stream interceptor should be outermost (first); order=%v", order)
+	}
+}
+
+// --- NRHttpTracer tests ---
+
+// newTestNRApp builds a disabled New Relic application suitable for tests —
+// no network calls, but Application / Transaction objects behave normally
+// including request-context propagation.
+func newTestNRApp(t *testing.T) *newrelic.Application {
+	t.Helper()
+	app, err := newrelic.NewApplication(
+		newrelic.ConfigAppName("test"),
+		newrelic.ConfigLicense(strings.Repeat("x", 40)),
+		newrelic.ConfigEnabled(false),
+	)
+	if err != nil {
+		t.Fatalf("newrelic.NewApplication: %v", err)
+	}
+	return app
+}
+
+func TestNRHttpTracer_NilApp(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	nrutil.SetNewRelicApp(nil)
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+
+	p, got := NRHttpTracer("/route", h)
+	if p != "/route" {
+		t.Errorf("pattern should be unchanged when NR app is nil; got %q", p)
+	}
+	// With no NR app, the function must return the original handler reference.
+	if fmt.Sprintf("%p", got) != fmt.Sprintf("%p", h) {
+		t.Error("expected original handler to be returned unchanged when NR app is nil")
+	}
+}
+
+// TestNRHttpTracer_FilterFuncAppliedForNonEmptyPattern guards issue #42:
+// when the pattern is non-empty, the configured filterFunc must still gate
+// NR instrumentation so filtered routes run the original handler without
+// starting a transaction.
+func TestNRHttpTracer_FilterFuncAppliedForNonEmptyPattern(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	nrutil.SetNewRelicApp(newTestNRApp(t))
+	defer nrutil.SetNewRelicApp(nil)
+
+	SetFilterFunc(context.Background(), func(_ context.Context, path string) bool {
+		return path != "/skip"
+	})
+
+	var sawTxn bool
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawTxn = newrelic.FromContext(r.Context()) != nil
+	})
+
+	_, wrapped := NRHttpTracer("/route", h)
+
+	sawTxn = false
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/skip", nil))
+	if sawTxn {
+		t.Error("filtered path should run without a New Relic transaction in request context")
+	}
+
+	sawTxn = false
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/keep", nil))
+	if !sawTxn {
+		t.Error("non-filtered path should run with a New Relic transaction in request context")
+	}
+}
+
+// TestNRHttpTracer_FilterFuncAppliedForEmptyPattern exercises the other
+// branch so a future regression in either path is caught.
+func TestNRHttpTracer_FilterFuncAppliedForEmptyPattern(t *testing.T) {
+	resetGlobals()
+	defer resetGlobals()
+
+	nrutil.SetNewRelicApp(newTestNRApp(t))
+	defer nrutil.SetNewRelicApp(nil)
+
+	SetFilterFunc(context.Background(), func(_ context.Context, path string) bool {
+		return path != "/skip"
+	})
+
+	var sawTxn bool
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawTxn = newrelic.FromContext(r.Context()) != nil
+	})
+
+	_, wrapped := NRHttpTracer("", h)
+
+	sawTxn = false
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/skip", nil))
+	if sawTxn {
+		t.Error("filtered path should run without a New Relic transaction in request context")
+	}
+
+	sawTxn = false
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/keep", nil))
+	if !sawTxn {
+		t.Error("non-filtered path should run with a New Relic transaction in request context")
 	}
 }


### PR DESCRIPTION
## Summary

When `pattern` was non-empty, `NRHttpTracer` returned `newrelic.WrapHandleFunc` directly and never consulted the configured `filterFunc`. Result: filtered routes (health checks, reflection, anything rejected by the filter) still started a New Relic transaction — exactly what the filter is meant to prevent. The empty-pattern branch already did the check correctly.

Fix: in the non-empty-pattern branch, wrap the handler returned by `WrapHandleFunc` with a filter-aware shell. Filtered paths fall through to the underlying handler; non-filtered paths go through the NR-instrumented handler as before.

Fixes #42.

## Test plan

- [x] New test `TestNRHttpTracer_FilterFuncAppliedForNonEmptyPattern` asserts a filtered path has no NR transaction in request context and a passing path has one. Verified the test fails on the pre-fix code.
- [x] Companion test `TestNRHttpTracer_FilterFuncAppliedForEmptyPattern` guards the other branch.
- [x] `TestNRHttpTracer_NilApp` confirms the nil-app short-circuit still returns the original handler unchanged.
- [x] `go test -race ./...` passes.
- [x] README regenerated via `make doc`.

https://claude.ai/code/session_01EWgytCisKXLiVp5BNhp2xE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-request filtering now determines whether New Relic instrumentation is applied based on request paths.

* **Documentation**
  * Documentation updated with detailed explanation of instrumentation behavior across different routing patterns and conditions.

* **Tests**
  * Comprehensive test coverage added for conditional instrumentation behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->