### PR TITLE
fix: detect any mutation of deprecated FilterMethods via content hash (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ If no executor is configured \(neither via [SetDefaultExecutor](<#SetDefaultExec
 Excluded errors and codes \(set via \[WithExcludedErrors\] / \[WithExcludedCodes\]\) are reported as nil to the executor, preventing them from tripping circuit breakers or retry logic. The original error is still returned to the caller.
 
 <a name="FilterMethodsFunc"></a>
-## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L99>)
+## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L101>)
 
 ```go
 func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
@@ -485,7 +485,7 @@ func SetFilterFunc(ctx context.Context, ff FilterFunc)
 SetFilterFunc sets the default filter function to be used by interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetFilterMethods"></a>
-## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L79>)
+## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L81>)
 
 ```go
 func SetFilterMethods(ctx context.Context, methods []string)

--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ const SupportPackageIsVersion1 = true
 var (
     // Deprecated: FilterMethods is the list of methods that are filtered by default.
     // Use SetFilterMethods instead. Any direct mutation (replacing the slice
-    // or editing it in place) is detected via a content hash, but
-    // SetFilterMethods is the supported API and avoids the per-call hash check
-    // cost.
+    // or editing it in place) is detected via a content hash.
+    // SetFilterMethods is the supported API for updating the filter list.
     FilterMethods = []string{"healthcheck", "readycheck", "serverreflectioninfo"}
 )
 ```
@@ -259,7 +258,7 @@ If no executor is configured \(neither via [SetDefaultExecutor](<#SetDefaultExec
 Excluded errors and codes \(set via \[WithExcludedErrors\] / \[WithExcludedCodes\]\) are reported as nil to the executor, preventing them from tripping circuit breakers or retry logic. The original error is still returned to the caller.
 
 <a name="FilterMethodsFunc"></a>
-## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L100>)
+## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L99>)
 
 ```go
 func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
@@ -486,7 +485,7 @@ func SetFilterFunc(ctx context.Context, ff FilterFunc)
 SetFilterFunc sets the default filter function to be used by interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetFilterMethods"></a>
-## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L80>)
+## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L79>)
 
 ```go
 func SetFilterMethods(ctx context.Context, methods []string)

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ const SupportPackageIsVersion1 = true
 ```go
 var (
     // Deprecated: FilterMethods is the list of methods that are filtered by default.
-    // Use SetFilterMethods instead. Only some direct mutations (replacing the slice
-    // or changing the first element) are detected by internal change detection;
-    // other in-place changes may not invalidate caches correctly.
+    // Use SetFilterMethods instead. Any direct mutation (replacing the slice
+    // or editing it in place) is detected via a content hash, but
+    // SetFilterMethods is the supported API and avoids the per-call hash check
+    // cost.
     FilterMethods = []string{"healthcheck", "readycheck", "serverreflectioninfo"}
 )
 ```
@@ -258,7 +259,7 @@ If no executor is configured \(neither via [SetDefaultExecutor](<#SetDefaultExec
 Excluded errors and codes \(set via \[WithExcludedErrors\] / \[WithExcludedCodes\]\) are reported as nil to the executor, preventing them from tripping circuit breakers or retry logic. The original error is still returned to the caller.
 
 <a name="FilterMethodsFunc"></a>
-## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L89>)
+## func [FilterMethodsFunc](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L100>)
 
 ```go
 func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
@@ -485,7 +486,7 @@ func SetFilterFunc(ctx context.Context, ff FilterFunc)
 SetFilterFunc sets the default filter function to be used by interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetFilterMethods"></a>
-## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L69>)
+## func [SetFilterMethods](<https://github.com/go-coldbrew/interceptors/blob/main/filter.go#L80>)
 
 ```go
 func SetFilterMethods(ctx context.Context, methods []string)

--- a/filter.go
+++ b/filter.go
@@ -15,9 +15,8 @@ type FilterFunc func(ctx context.Context, fullMethodName string) bool
 var (
 	// Deprecated: FilterMethods is the list of methods that are filtered by default.
 	// Use SetFilterMethods instead. Any direct mutation (replacing the slice
-	// or editing it in place) is detected via a content hash, but
-	// SetFilterMethods is the supported API and avoids the per-call hash check
-	// cost.
+	// or editing it in place) is detected via a content hash.
+	// SetFilterMethods is the supported API for updating the filter list.
 	FilterMethods = []string{"healthcheck", "readycheck", "serverreflectioninfo"}
 )
 
@@ -46,13 +45,13 @@ func hashFilterMethods(s []string) uint64 {
 	)
 	h := offset64
 	for _, v := range s {
+		// hash the length first so ["ab","c"] and ["a","bc"] cannot collide
+		h ^= uint64(len(v))
+		h *= prime64
 		for i := 0; i < len(v); i++ {
 			h ^= uint64(v[i])
 			h *= prime64
 		}
-		// separator byte so ["ab","c"] and ["a","bc"] hash differently
-		h ^= 0
-		h *= prime64
 	}
 	return h
 }

--- a/filter.go
+++ b/filter.go
@@ -36,8 +36,9 @@ func init() {
 }
 
 // hashFilterMethods returns an FNV-1a 64-bit hash of the slice contents.
-// Inline so it allocates nothing — it runs on every FilterMethodsFunc call
-// to detect direct mutations of the deprecated FilterMethods variable.
+// Written to avoid allocations (no []byte conversions or fmt calls) because
+// it runs on every FilterMethodsFunc call to detect direct mutations of
+// the deprecated FilterMethods variable.
 func hashFilterMethods(s []string) uint64 {
 	const (
 		offset64 uint64 = 14695981039346656037
@@ -45,7 +46,8 @@ func hashFilterMethods(s []string) uint64 {
 	)
 	h := offset64
 	for _, v := range s {
-		// hash the length first so ["ab","c"] and ["a","bc"] cannot collide
+		// Mix the length first so ["ab","c"] and ["a","bc"] produce
+		// different input byte streams for the hash.
 		h ^= uint64(len(v))
 		h *= prime64
 		for i := 0; i < len(v); i++ {

--- a/filter.go
+++ b/filter.go
@@ -14,9 +14,10 @@ type FilterFunc func(ctx context.Context, fullMethodName string) bool
 
 var (
 	// Deprecated: FilterMethods is the list of methods that are filtered by default.
-	// Use SetFilterMethods instead. Only some direct mutations (replacing the slice
-	// or changing the first element) are detected by internal change detection;
-	// other in-place changes may not invalidate caches correctly.
+	// Use SetFilterMethods instead. Any direct mutation (replacing the slice
+	// or editing it in place) is detected via a content hash, but
+	// SetFilterMethods is the supported API and avoids the per-call hash check
+	// cost.
 	FilterMethods = []string{"healthcheck", "readycheck", "serverreflectioninfo"}
 )
 
@@ -24,10 +25,9 @@ var (
 // A new filterState is created whenever FilterMethods changes, which
 // atomically invalidates the old cache.
 type filterState struct {
-	methods     []string // lowercased filter substrings
-	cache       sync.Map // map[string]bool
-	sourceLen   int      // len(FilterMethods) when this state was built
-	sourceFirst string   // FilterMethods[0] when built (fast mutation check)
+	methods    []string // lowercased filter substrings
+	cache      sync.Map // map[string]bool
+	sourceHash uint64   // FNV-1a hash of FilterMethods at build time
 }
 
 var currentFilter atomic.Pointer[filterState]
@@ -36,31 +36,42 @@ func init() {
 	currentFilter.Store(buildFilterState())
 }
 
+// hashFilterMethods returns an FNV-1a 64-bit hash of the slice contents.
+// Inline so it allocates nothing — it runs on every FilterMethodsFunc call
+// to detect direct mutations of the deprecated FilterMethods variable.
+func hashFilterMethods(s []string) uint64 {
+	const (
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
+	)
+	h := offset64
+	for _, v := range s {
+		for i := 0; i < len(v); i++ {
+			h ^= uint64(v[i])
+			h *= prime64
+		}
+		// separator byte so ["ab","c"] and ["a","bc"] hash differently
+		h ^= 0
+		h *= prime64
+	}
+	return h
+}
+
 func buildFilterState() *filterState {
 	lower := make([]string, len(FilterMethods))
 	for i, m := range FilterMethods {
 		lower[i] = strings.ToLower(m)
 	}
-	s := &filterState{
-		methods:   lower,
-		sourceLen: len(FilterMethods),
+	return &filterState{
+		methods:    lower,
+		sourceHash: hashFilterMethods(FilterMethods),
 	}
-	if len(FilterMethods) > 0 {
-		s.sourceFirst = FilterMethods[0]
-	}
-	return s
 }
 
 // changed reports whether the deprecated FilterMethods variable
 // has been mutated since this filterState was built.
 func (s *filterState) changed() bool {
-	if len(FilterMethods) != s.sourceLen {
-		return true
-	}
-	if s.sourceLen > 0 && FilterMethods[0] != s.sourceFirst {
-		return true
-	}
-	return false
+	return hashFilterMethods(FilterMethods) != s.sourceHash
 }
 
 // SetFilterMethods sets the list of method substrings to exclude from tracing/logging.

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -131,6 +131,36 @@ func TestSetFilterMethods(t *testing.T) {
 	}
 }
 
+// TestFilterMethods_DirectMutationDetected guards issue #41: the cache must
+// invalidate when the deprecated FilterMethods var is mutated in place,
+// including at indices beyond 0 (which the old length/first-element probe
+// missed).
+func TestFilterMethods_DirectMutationDetected(t *testing.T) {
+	defer resetGlobals()
+	ctx := grpcContext()
+
+	// Prime the cache.
+	if !FilterMethodsFunc(ctx, "/svc.A/Foo") {
+		t.Fatal("expected /svc.A/Foo to pass default filter")
+	}
+	if FilterMethodsFunc(ctx, "/svc.A/healthcheck") {
+		t.Fatal("expected /svc.A/healthcheck to be filtered by default")
+	}
+
+	// Mutate an element other than index 0 — the old detection would miss this.
+	// Default is {"healthcheck", "readycheck", "serverreflectioninfo"}; replace
+	// "readycheck" with "foo" so /svc.A/Foo should now be filtered and
+	// /svc.A/readycheck should pass.
+	FilterMethods[1] = "foo"
+
+	if FilterMethodsFunc(ctx, "/svc.A/Foo") {
+		t.Error("/svc.A/Foo should be filtered after index-1 mutation")
+	}
+	if !FilterMethodsFunc(ctx, "/svc.A/readycheck") {
+		t.Error("/svc.A/readycheck should pass after 'readycheck' was replaced at index 1")
+	}
+}
+
 func TestFilterMethodsFunc_HTTPPathNotCached(t *testing.T) {
 	defer resetGlobals()
 	// HTTP context (no gRPC metadata) — results should not be cached.


### PR DESCRIPTION
## Summary

`FilterMethodsFunc` caches decisions per method name, and `filterState.changed()` is supposed to rebuild (and therefore invalidate) the cache when the deprecated exported `FilterMethods` var is mutated directly. The old implementation only compared `len(FilterMethods)` and `FilterMethods[0]`, so a mutation at index ≥ 1 (e.g. `FilterMethods[1] = "foo"`) left stale cached decisions in place.

Replace the length/first-element probe with a zero-allocation inline FNV-1a 64-bit hash of the slice contents, recorded at `buildFilterState` time and recomputed on every filter call. Any whole-slice replacement or in-place edit changes the hash, the state rebuilds, and the cache invalidates.

`SetFilterMethods` is still the supported API. The var stays deprecated; the godoc now accurately describes the detection behavior.

Fixes #41.

## Test plan

- [x] New test `TestFilterMethods_DirectMutationDetected` mutates `FilterMethods[1]` after priming the cache and asserts the new filter list takes effect. Verified it fails on the pre-fix code.
- [x] Existing tests (`TestSetFilterMethods`, `TestFilterMethodsFunc`, `TestFilterMethodsFunc_HTTPPathNotCached`) still pass.
- [x] `go test -race ./...` passes.
- [x] README regenerated via `make doc`.

https://claude.ai/code/session_01EWgytCisKXLiVp5BNhp2xE