### PR TITLE
fix: preserve accumulated metrics on AlreadyRegisteredError (#43)

### DIFF
--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -2352,6 +2352,18 @@ func TestRegisterOrReuse_NewRegistration(t *testing.T) {
 	if got != prometheus.Collector(c) {
 		t.Error("expected registerOrReuse to return the newly-registered collector")
 	}
+
+	// Confirm registration actually happened — a second Register of the same
+	// collector should fail with AlreadyRegisteredError whose ExistingCollector
+	// is c. Guards against an error path that returns c without registering.
+	err := prometheus.Register(c)
+	if err == nil {
+		t.Fatal("expected duplicate registration to fail; collector was not registered by registerOrReuse")
+	}
+	var are prometheus.AlreadyRegisteredError
+	if !errors.As(err, &are) || are.ExistingCollector != prometheus.Collector(c) {
+		t.Fatalf("expected duplicate registration to return the registered collector, got %v", err)
+	}
 }
 
 // TestRegisterOrReuse_ReusesExisting guards issue #43: when a collector with

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -20,6 +20,7 @@ import (
 	ratelimit_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	newrelic "github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcmd "google.golang.org/grpc/metadata"
@@ -2332,5 +2333,49 @@ func TestNRHttpTracer_FilterFuncAppliedForEmptyPattern(t *testing.T) {
 	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/keep", nil))
 	if !sawTxn {
 		t.Error("non-filtered path should run with a New Relic transaction in request context")
+	}
+}
+
+// --- registerOrReuse tests (issue #43) ---
+
+// TestRegisterOrReuse_NewRegistration exercises the happy path: a collector
+// that is not yet registered is registered, and the same collector is
+// returned.
+func TestRegisterOrReuse_NewRegistration(t *testing.T) {
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_registerorreuse_new",
+		Help: "test",
+	})
+	defer prometheus.Unregister(c)
+
+	got := registerOrReuse(c)
+	if got != prometheus.Collector(c) {
+		t.Error("expected registerOrReuse to return the newly-registered collector")
+	}
+}
+
+// TestRegisterOrReuse_ReusesExisting guards issue #43: when a collector with
+// the same name is already registered, registerOrReuse must return the
+// already-registered instance so its accumulated observations are preserved.
+// The previous Unregister+Register pattern would have dropped them.
+func TestRegisterOrReuse_ReusesExisting(t *testing.T) {
+	first := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_registerorreuse_existing",
+		Help: "test",
+	})
+	if err := prometheus.Register(first); err != nil {
+		t.Fatalf("pre-register failed: %v", err)
+	}
+	defer prometheus.Unregister(first)
+	first.Inc() // accumulate an observation that must not be lost
+
+	second := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_registerorreuse_existing",
+		Help: "test",
+	})
+
+	got := registerOrReuse(second)
+	if got != prometheus.Collector(first) {
+		t.Error("expected registerOrReuse to return the already-registered collector, not the new one")
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -17,32 +17,51 @@ var (
 	cltMetrics     *grpcprom.ClientMetrics
 )
 
-func registerCollector(c prometheus.Collector) {
-	if err := prometheus.Register(c); err != nil {
-		var are prometheus.AlreadyRegisteredError
-		if stdError.As(err, &are) {
-			prometheus.Unregister(are.ExistingCollector)
-			if err := prometheus.Register(c); err != nil {
-				log.Warn(context.Background(), "msg", "failed to re-register gRPC metrics with Prometheus", "err", err)
-			}
-			return
-		}
-		log.Error(context.Background(), "msg", "gRPC Prometheus metrics registration failed. If you are using github.com/go-coldbrew/core, it may need to be updated to the latest version.", "err", err)
+// registerOrReuse registers c with the default Prometheus registry and
+// returns the collector that is actually registered. If a collector with
+// the same fully-qualified name is already registered, returns that
+// existing collector so its accumulated observations are preserved —
+// callers should swap to the returned collector rather than use the
+// argument, which would otherwise be dropped. On any other registration
+// error, logs and returns c so callers still get a usable instance (its
+// observations will not be exported).
+func registerOrReuse(c prometheus.Collector) prometheus.Collector {
+	err := prometheus.Register(c)
+	if err == nil {
+		return c
 	}
+	var are prometheus.AlreadyRegisteredError
+	if stdError.As(err, &are) {
+		return are.ExistingCollector
+	}
+	log.Error(context.Background(), "msg", "gRPC Prometheus metrics registration failed. If you are using github.com/go-coldbrew/core, it may need to be updated to the latest version.", "err", err)
+	return c
 }
 
 func getServerMetrics() *grpcprom.ServerMetrics {
 	srvMetricsOnce.Do(func() {
-		srvMetrics = grpcprom.NewServerMetrics(defaultConfig.srvMetricsOpts...)
-		registerCollector(srvMetrics)
+		m := grpcprom.NewServerMetrics(defaultConfig.srvMetricsOpts...)
+		reused := registerOrReuse(m)
+		if typed, ok := reused.(*grpcprom.ServerMetrics); ok {
+			srvMetrics = typed
+			return
+		}
+		log.Warn(context.Background(), "msg", "existing gRPC server metrics collector has an unexpected type; using the new (unregistered) instance", "existing", reused)
+		srvMetrics = m
 	})
 	return srvMetrics
 }
 
 func getClientMetrics() *grpcprom.ClientMetrics {
 	cltMetricsOnce.Do(func() {
-		cltMetrics = grpcprom.NewClientMetrics(defaultConfig.cltMetricsOpts...)
-		registerCollector(cltMetrics)
+		m := grpcprom.NewClientMetrics(defaultConfig.cltMetricsOpts...)
+		reused := registerOrReuse(m)
+		if typed, ok := reused.(*grpcprom.ClientMetrics); ok {
+			cltMetrics = typed
+			return
+		}
+		log.Warn(context.Background(), "msg", "existing gRPC client metrics collector has an unexpected type; using the new (unregistered) instance", "existing", reused)
+		cltMetrics = m
 	})
 	return cltMetrics
 }

--- a/metrics.go
+++ b/metrics.go
@@ -18,12 +18,12 @@ var (
 )
 
 // registerOrReuse registers c with the default Prometheus registry and
-// returns the collector that is actually registered. If a collector with
-// the same fully-qualified name is already registered, returns that
-// existing collector so its accumulated observations are preserved —
-// callers should swap to the returned collector rather than use the
-// argument, which would otherwise be dropped. On any other registration
-// error, logs and returns c so callers still get a usable instance (its
+// returns the collector callers should use. If a collector with the same
+// fully-qualified name is already registered, returns that existing
+// collector so its accumulated observations are preserved — callers
+// should swap to the returned collector rather than use the argument,
+// which would otherwise be dropped. On any other registration error,
+// logs and returns c so callers still get a usable instance (its
 // observations will not be exported).
 func registerOrReuse(c prometheus.Collector) prometheus.Collector {
 	err := prometheus.Register(c)


### PR DESCRIPTION
## Summary

`registerCollector` handled `AlreadyRegisteredError` by calling `prometheus.Unregister(existing)` and then re-registering the new collector. That discards any counters / histograms already accumulated in the existing collector — observably bad on hot-reload, in processes that embed the package more than once, and in tests.

Replace with `registerOrReuse`, which on `AlreadyRegisteredError` returns the already-registered collector. `getServerMetrics` / `getClientMetrics` now swap `srvMetrics` / `cltMetrics` to the reused instance via a type assertion; the freshly-built (unregistered) collector is dropped and the existing one continues to record.

If the existing collector is of an unexpected type (shouldn't normally happen), log and fall back to the new instance. This matches the current degraded behavior (observations not exported) but no longer unregisters the existing collector.

Fixes #43.

## Test plan

- [x] `TestRegisterOrReuse_NewRegistration` — happy path registers and returns the argument.
- [x] `TestRegisterOrReuse_ReusesExisting` — pre-registers a collector, calls `registerOrReuse` with a same-named new one, asserts the existing one is returned. Verified to fail on the pre-fix (unregister+re-register) behavior.
- [x] `go test -race ./...` passes.

https://claude.ai/code/session_01EWgytCisKXLiVp5BNhp2xE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for metric collector registration scenarios, including tests for new collector registration and verification of existing collector reuse.

* **Bug Fixes**
  * Improved metrics registration reliability by implementing detection and reuse of previously registered collectors, eliminating the previous approach of attempting to unregister and re-register.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->