### PR TITLE
fix: surface protovalidate misconfig at SetProtoValidateOptions time (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Interceptor configuration functions \(AddUnaryServerInterceptor, SetFilterFunc, 
 - [func SetDisableRateLimit\(disable bool\)](<#SetDisableRateLimit>)
 - [func SetFilterFunc\(ctx context.Context, ff FilterFunc\)](<#SetFilterFunc>)
 - [func SetFilterMethods\(ctx context.Context, methods \[\]string\)](<#SetFilterMethods>)
-- [func SetProtoValidateOptions\(opts ...protovalidate.ValidatorOption\)](<#SetProtoValidateOptions>)
+- [func SetProtoValidateOptions\(opts ...protovalidate.ValidatorOption\) error](<#SetProtoValidateOptions>)
 - [func SetRateLimiter\(limiter ratelimit\_middleware.Limiter\)](<#SetRateLimiter>)
 - [func SetResponseTimeLogErrorOnly\(errorOnly bool\)](<#SetResponseTimeLogErrorOnly>)
 - [func SetResponseTimeLogLevel\(ctx context.Context, level loggers.Level\)](<#SetResponseTimeLogLevel>)
@@ -97,7 +97,7 @@ var (
 ```
 
 <a name="AddStreamClientInterceptor"></a>
-## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L125>)
+## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L126>)
 
 ```go
 func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInterceptor)
@@ -106,7 +106,7 @@ func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInter
 AddStreamClientInterceptor adds a client stream interceptor to default client stream interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddStreamServerInterceptor"></a>
-## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L106>)
+## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L107>)
 
 ```go
 func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInterceptor)
@@ -115,7 +115,7 @@ func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInter
 AddStreamServerInterceptor adds a server interceptor to default server interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="AddUnaryClientInterceptor"></a>
-## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L119>)
+## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L120>)
 
 ```go
 func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterceptor)
@@ -124,7 +124,7 @@ func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterce
 AddUnaryClientInterceptor adds a client interceptor to default client interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddUnaryServerInterceptor"></a>
-## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L100>)
+## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L101>)
 
 ```go
 func AddUnaryServerInterceptor(ctx context.Context, i ...grpc.UnaryServerInterceptor)
@@ -133,7 +133,7 @@ func AddUnaryServerInterceptor(ctx context.Context, i ...grpc.UnaryServerInterce
 AddUnaryServerInterceptor adds a server interceptor to default server interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="DebugLogInterceptor"></a>
-## func [DebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L396>)
+## func [DebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L400>)
 
 ```go
 func DebugLogInterceptor() grpc.UnaryServerInterceptor
@@ -147,7 +147,7 @@ DebugLogInterceptor enables per\-request log level override based on a proto fie
 Combined with ColdBrew's trace ID propagation, this allows enabling debug logging for a single request and following it across services via trace ID.
 
 <a name="DebugLoggingInterceptor"></a>
-## func [DebugLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L422>)
+## func [DebugLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L426>)
 
 ```go
 func DebugLoggingInterceptor() grpc.UnaryServerInterceptor
@@ -192,7 +192,7 @@ func DefaultClientStreamInterceptors(defaultOpts ...any) []grpc.StreamClientInte
 DefaultClientStreamInterceptors are the set of default interceptors that should be applied to all stream client calls
 
 <a name="DefaultInterceptors"></a>
-## func [DefaultInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L130>)
+## func [DefaultInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L134>)
 
 ```go
 func DefaultInterceptors() []grpc.UnaryServerInterceptor
@@ -201,7 +201,7 @@ func DefaultInterceptors() []grpc.UnaryServerInterceptor
 DefaultInterceptors returns the default unary server interceptor chain. The ordering is defined by the unaryPos\* constants above; this function assigns each interceptor to its named slot and drops any slot that is disabled via configuration. See the ordering contract above for semantics.
 
 <a name="DefaultStreamInterceptors"></a>
-## func [DefaultStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L170>)
+## func [DefaultStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L174>)
 
 ```go
 func DefaultStreamInterceptors() []grpc.StreamServerInterceptor
@@ -210,7 +210,7 @@ func DefaultStreamInterceptors() []grpc.StreamServerInterceptor
 DefaultStreamInterceptors returns the default stream server interceptor chain. The ordering is defined by the streamPos\* constants above; this function assigns each interceptor to its named slot and drops any slot that is disabled via configuration. See the ordering contract above for semantics.
 
 <a name="DefaultTimeoutInterceptor"></a>
-## func [DefaultTimeoutInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L203>)
+## func [DefaultTimeoutInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L207>)
 
 ```go
 func DefaultTimeoutInterceptor() grpc.UnaryServerInterceptor
@@ -276,7 +276,7 @@ func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
 Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by google.golang.org/grpc/stats/opentelemetry, configured via opentelemetry.DialOption\(\) at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
 
 <a name="GetDebugLogHeaderName"></a>
-## func [GetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L180>)
+## func [GetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L201>)
 
 ```go
 func GetDebugLogHeaderName() string
@@ -314,7 +314,7 @@ func NewRelicClientInterceptor() grpc.UnaryClientInterceptor
 NewRelicClientInterceptor intercepts all client actions and reports them to newrelic. When NewRelic app is nil \(no license key configured\), returns a pass\-through interceptor to avoid overhead.
 
 <a name="NewRelicInterceptor"></a>
-## func [NewRelicInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L269>)
+## func [NewRelicInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L273>)
 
 ```go
 func NewRelicInterceptor() grpc.UnaryServerInterceptor
@@ -323,7 +323,7 @@ func NewRelicInterceptor() grpc.UnaryServerInterceptor
 NewRelicInterceptor intercepts all server actions and reports them to newrelic. When NewRelic app is nil \(no license key configured\), returns a pass\-through interceptor to avoid overhead.
 
 <a name="OptionsInterceptor"></a>
-## func [OptionsInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L259>)
+## func [OptionsInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L263>)
 
 ```go
 func OptionsInterceptor() grpc.UnaryServerInterceptor
@@ -332,7 +332,7 @@ func OptionsInterceptor() grpc.UnaryServerInterceptor
 
 
 <a name="PanicRecoveryInterceptor"></a>
-## func [PanicRecoveryInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L329>)
+## func [PanicRecoveryInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L333>)
 
 ```go
 func PanicRecoveryInterceptor() grpc.UnaryServerInterceptor
@@ -341,7 +341,7 @@ func PanicRecoveryInterceptor() grpc.UnaryServerInterceptor
 
 
 <a name="PanicRecoveryStreamInterceptor"></a>
-## func [PanicRecoveryStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L353>)
+## func [PanicRecoveryStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L357>)
 
 ```go
 func PanicRecoveryStreamInterceptor() grpc.StreamServerInterceptor
@@ -350,7 +350,7 @@ func PanicRecoveryStreamInterceptor() grpc.StreamServerInterceptor
 PanicRecoveryStreamInterceptor recovers from panics in stream handlers, logs the panic and stack trace, and reports it to the error notifier.
 
 <a name="ProtoValidateInterceptor"></a>
-## func [ProtoValidateInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L53>)
+## func [ProtoValidateInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L57>)
 
 ```go
 func ProtoValidateInterceptor() grpc.UnaryServerInterceptor
@@ -359,7 +359,7 @@ func ProtoValidateInterceptor() grpc.UnaryServerInterceptor
 ProtoValidateInterceptor returns a unary server interceptor that validates incoming messages using protovalidate annotations. Returns InvalidArgument on validation failure. Uses GlobalValidator by default; if custom options are set via SetProtoValidateOptions, creates a new validator with those options.
 
 <a name="ProtoValidateStreamInterceptor"></a>
-## func [ProtoValidateStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L59>)
+## func [ProtoValidateStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L63>)
 
 ```go
 func ProtoValidateStreamInterceptor() grpc.StreamServerInterceptor
@@ -368,7 +368,7 @@ func ProtoValidateStreamInterceptor() grpc.StreamServerInterceptor
 ProtoValidateStreamInterceptor returns a stream server interceptor that validates incoming messages using protovalidate annotations.
 
 <a name="ResponseTimeLoggingInterceptor"></a>
-## func [ResponseTimeLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L218>)
+## func [ResponseTimeLoggingInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L222>)
 
 ```go
 func ResponseTimeLoggingInterceptor(ff FilterFunc) grpc.UnaryServerInterceptor
@@ -377,7 +377,7 @@ func ResponseTimeLoggingInterceptor(ff FilterFunc) grpc.UnaryServerInterceptor
 ResponseTimeLoggingInterceptor logs response time for each request on server
 
 <a name="ResponseTimeLoggingStreamInterceptor"></a>
-## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L241>)
+## func [ResponseTimeLoggingStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L245>)
 
 ```go
 func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor
@@ -386,7 +386,7 @@ func ResponseTimeLoggingStreamInterceptor() grpc.StreamServerInterceptor
 ResponseTimeLoggingStreamInterceptor logs response time for stream RPCs.
 
 <a name="ServerErrorInterceptor"></a>
-## func [ServerErrorInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L287>)
+## func [ServerErrorInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L291>)
 
 ```go
 func ServerErrorInterceptor() grpc.UnaryServerInterceptor
@@ -395,7 +395,7 @@ func ServerErrorInterceptor() grpc.UnaryServerInterceptor
 ServerErrorInterceptor intercepts all server actions and reports them to error notifier
 
 <a name="ServerErrorStreamInterceptor"></a>
-## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L313>)
+## func [ServerErrorStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L317>)
 
 ```go
 func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
@@ -404,7 +404,7 @@ func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
 ServerErrorStreamInterceptor intercepts server errors for stream RPCs and reports them to the error notifier.
 
 <a name="SetClientMetricsOptions"></a>
-## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L144>)
+## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L145>)
 
 ```go
 func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
@@ -413,7 +413,7 @@ func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
 SetClientMetricsOptions appends gRPC client metrics options. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDebugLogHeaderName"></a>
-## func [SetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L171>)
+## func [SetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L192>)
 
 ```go
 func SetDebugLogHeaderName(name string)
@@ -422,7 +422,7 @@ func SetDebugLogHeaderName(name string)
 SetDebugLogHeaderName sets the gRPC metadata header name that triggers per\-request log level override. Default is "x\-debug\-log\-level". The header value should be a valid log level \(e.g., "debug"\). Empty names are ignored. Must be called during initialization.
 
 <a name="SetDefaultExecutor"></a>
-## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L214>)
+## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L235>)
 
 ```go
 func SetDefaultExecutor(e Executor)
@@ -431,7 +431,7 @@ func SetDefaultExecutor(e Executor)
 SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for all outbound unary RPCs. When set, ExecutorClientInterceptor replaces [HystrixClientInterceptor](<#HystrixClientInterceptor>) in the default client interceptor chain. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDefaultRateLimit"></a>
-## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L202>)
+## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L223>)
 
 ```go
 func SetDefaultRateLimit(rps float64, burst int)
@@ -440,7 +440,7 @@ func SetDefaultRateLimit(rps float64, burst int)
 SetDefaultRateLimit configures the built\-in token bucket rate limiter. rps is requests per second, burst is the maximum burst size. This is a per\-pod in\-memory limit — with N pods, the effective cluster\-wide limit is N × rps. For distributed rate limiting, use SetRateLimiter\(\) with a custom implementation \(e.g., Redis\-backed\). Must be called during initialization.
 
 <a name="SetDefaultTimeout"></a>
-## func [SetDefaultTimeout](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L86>)
+## func [SetDefaultTimeout](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L87>)
 
 ```go
 func SetDefaultTimeout(d time.Duration)
@@ -449,7 +449,7 @@ func SetDefaultTimeout(d time.Duration)
 SetDefaultTimeout sets the default timeout applied to incoming unary RPCs that arrive without a deadline. When set to \<= 0, the timeout interceptor is disabled \(pass\-through\). Default is 60s. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetDisableDebugLogInterceptor"></a>
-## func [SetDisableDebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L163>)
+## func [SetDisableDebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L184>)
 
 ```go
 func SetDisableDebugLogInterceptor(disable bool)
@@ -458,7 +458,7 @@ func SetDisableDebugLogInterceptor(disable bool)
 SetDisableDebugLogInterceptor disables the DebugLogInterceptor in the default interceptor chain. Must be called during initialization, before the server starts.
 
 <a name="SetDisableProtoValidate"></a>
-## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L157>)
+## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L178>)
 
 ```go
 func SetDisableProtoValidate(disable bool)
@@ -467,7 +467,7 @@ func SetDisableProtoValidate(disable bool)
 SetDisableProtoValidate disables the protovalidate interceptor in the default chain. Must be called during init\(\) — not safe for concurrent use.
 
 <a name="SetDisableRateLimit"></a>
-## func [SetDisableRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L186>)
+## func [SetDisableRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L207>)
 
 ```go
 func SetDisableRateLimit(disable bool)
@@ -476,7 +476,7 @@ func SetDisableRateLimit(disable bool)
 SetDisableRateLimit disables the rate limiting interceptor in the default interceptor chain. Must be called during initialization.
 
 <a name="SetFilterFunc"></a>
-## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L92>)
+## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L93>)
 
 ```go
 func SetFilterFunc(ctx context.Context, ff FilterFunc)
@@ -494,16 +494,18 @@ func SetFilterMethods(ctx context.Context, methods []string)
 SetFilterMethods sets the list of method substrings to exclude from tracing/logging. It rebuilds the internal cache. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetProtoValidateOptions"></a>
-## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L151>)
+## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L165>)
 
 ```go
-func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption)
+func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error
 ```
 
 SetProtoValidateOptions configures custom protovalidate options \(e.g., custom constraints\). Must be called during init\(\) — not safe for concurrent use. Follows ColdBrew's init\-only config pattern.
 
+The combined option set \(existing \+ new\) is validated immediately by constructing a protovalidate.Validator. If construction fails, the new options are NOT appended and the error is returned so the caller can surface it \(typically by failing process startup\). Callers that ignore the error keep working with whatever option set was last accepted — the lazy getProtoValidator path still falls back to GlobalValidator on error as a defensive backstop.
+
 <a name="SetRateLimiter"></a>
-## func [SetRateLimiter](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L192>)
+## func [SetRateLimiter](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L213>)
 
 ```go
 func SetRateLimiter(limiter ratelimit_middleware.Limiter)
@@ -512,7 +514,7 @@ func SetRateLimiter(limiter ratelimit_middleware.Limiter)
 SetRateLimiter sets a custom rate limiter implementation. This overrides the built\-in token bucket limiter. Must be called during initialization.
 
 <a name="SetResponseTimeLogErrorOnly"></a>
-## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L78>)
+## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L79>)
 
 ```go
 func SetResponseTimeLogErrorOnly(errorOnly bool)
@@ -521,7 +523,7 @@ func SetResponseTimeLogErrorOnly(errorOnly bool)
 SetResponseTimeLogErrorOnly when set to true, only logs response time when the request returns an error. Successful requests are not logged. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetResponseTimeLogLevel"></a>
-## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L71>)
+## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L72>)
 
 ```go
 func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
@@ -530,7 +532,7 @@ func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
 SetResponseTimeLogLevel sets the log level for response time logging. Default is InfoLevel. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetServerMetricsOptions"></a>
-## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L138>)
+## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L139>)
 
 ```go
 func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
@@ -539,7 +541,7 @@ func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
 SetServerMetricsOptions appends gRPC server metrics options \(histogram, labels, namespace, etc.\). Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="TraceIdInterceptor"></a>
-## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L374>)
+## func [TraceIdInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/server.go#L378>)
 
 ```go
 func TraceIdInterceptor() grpc.UnaryServerInterceptor
@@ -548,7 +550,7 @@ func TraceIdInterceptor() grpc.UnaryServerInterceptor
 TraceIdInterceptor allows injecting trace id from request objects
 
 <a name="UseColdBrewClientInterceptors"></a>
-## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L132>)
+## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L133>)
 
 ```go
 func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
@@ -557,7 +559,7 @@ func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
 UseColdBrewClientInterceptors allows enabling/disabling coldbrew client interceptors. When set to false, the coldbrew client interceptors will not be used. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="UseColdBrewServerInterceptors"></a>
-## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L113>)
+## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L114>)
 
 ```go
 func UseColdBrewServerInterceptors(ctx context.Context, flag bool)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var (
 ```
 
 <a name="AddStreamClientInterceptor"></a>
-## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L126>)
+## func [AddStreamClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L127>)
 
 ```go
 func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInterceptor)
@@ -106,7 +106,7 @@ func AddStreamClientInterceptor(ctx context.Context, i ...grpc.StreamClientInter
 AddStreamClientInterceptor adds a client stream interceptor to default client stream interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddStreamServerInterceptor"></a>
-## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L107>)
+## func [AddStreamServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L108>)
 
 ```go
 func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInterceptor)
@@ -115,7 +115,7 @@ func AddStreamServerInterceptor(ctx context.Context, i ...grpc.StreamServerInter
 AddStreamServerInterceptor adds a server interceptor to default server interceptors. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="AddUnaryClientInterceptor"></a>
-## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L120>)
+## func [AddUnaryClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L121>)
 
 ```go
 func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterceptor)
@@ -124,7 +124,7 @@ func AddUnaryClientInterceptor(ctx context.Context, i ...grpc.UnaryClientInterce
 AddUnaryClientInterceptor adds a client interceptor to default client interceptors. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="AddUnaryServerInterceptor"></a>
-## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L101>)
+## func [AddUnaryServerInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L102>)
 
 ```go
 func AddUnaryServerInterceptor(ctx context.Context, i ...grpc.UnaryServerInterceptor)
@@ -276,7 +276,7 @@ func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
 Deprecated: GRPCClientInterceptor is no longer needed. gRPC tracing is now handled by google.golang.org/grpc/stats/opentelemetry, configured via opentelemetry.DialOption\(\) at the client level. This function is retained for backwards compatibility but returns a no\-op interceptor.
 
 <a name="GetDebugLogHeaderName"></a>
-## func [GetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L201>)
+## func [GetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L209>)
 
 ```go
 func GetDebugLogHeaderName() string
@@ -404,7 +404,7 @@ func ServerErrorStreamInterceptor() grpc.StreamServerInterceptor
 ServerErrorStreamInterceptor intercepts server errors for stream RPCs and reports them to the error notifier.
 
 <a name="SetClientMetricsOptions"></a>
-## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L145>)
+## func [SetClientMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L146>)
 
 ```go
 func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
@@ -413,7 +413,7 @@ func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption)
 SetClientMetricsOptions appends gRPC client metrics options. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDebugLogHeaderName"></a>
-## func [SetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L192>)
+## func [SetDebugLogHeaderName](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L200>)
 
 ```go
 func SetDebugLogHeaderName(name string)
@@ -422,7 +422,7 @@ func SetDebugLogHeaderName(name string)
 SetDebugLogHeaderName sets the gRPC metadata header name that triggers per\-request log level override. Default is "x\-debug\-log\-level". The header value should be a valid log level \(e.g., "debug"\). Empty names are ignored. Must be called during initialization.
 
 <a name="SetDefaultExecutor"></a>
-## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L235>)
+## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L243>)
 
 ```go
 func SetDefaultExecutor(e Executor)
@@ -431,7 +431,7 @@ func SetDefaultExecutor(e Executor)
 SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for all outbound unary RPCs. When set, ExecutorClientInterceptor replaces [HystrixClientInterceptor](<#HystrixClientInterceptor>) in the default client interceptor chain. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDefaultRateLimit"></a>
-## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L223>)
+## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L231>)
 
 ```go
 func SetDefaultRateLimit(rps float64, burst int)
@@ -440,7 +440,7 @@ func SetDefaultRateLimit(rps float64, burst int)
 SetDefaultRateLimit configures the built\-in token bucket rate limiter. rps is requests per second, burst is the maximum burst size. This is a per\-pod in\-memory limit — with N pods, the effective cluster\-wide limit is N × rps. For distributed rate limiting, use SetRateLimiter\(\) with a custom implementation \(e.g., Redis\-backed\). Must be called during initialization.
 
 <a name="SetDefaultTimeout"></a>
-## func [SetDefaultTimeout](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L87>)
+## func [SetDefaultTimeout](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L88>)
 
 ```go
 func SetDefaultTimeout(d time.Duration)
@@ -449,7 +449,7 @@ func SetDefaultTimeout(d time.Duration)
 SetDefaultTimeout sets the default timeout applied to incoming unary RPCs that arrive without a deadline. When set to \<= 0, the timeout interceptor is disabled \(pass\-through\). Default is 60s. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetDisableDebugLogInterceptor"></a>
-## func [SetDisableDebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L184>)
+## func [SetDisableDebugLogInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L192>)
 
 ```go
 func SetDisableDebugLogInterceptor(disable bool)
@@ -458,7 +458,7 @@ func SetDisableDebugLogInterceptor(disable bool)
 SetDisableDebugLogInterceptor disables the DebugLogInterceptor in the default interceptor chain. Must be called during initialization, before the server starts.
 
 <a name="SetDisableProtoValidate"></a>
-## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L178>)
+## func [SetDisableProtoValidate](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L186>)
 
 ```go
 func SetDisableProtoValidate(disable bool)
@@ -467,7 +467,7 @@ func SetDisableProtoValidate(disable bool)
 SetDisableProtoValidate disables the protovalidate interceptor in the default chain. Must be called during init\(\) — not safe for concurrent use.
 
 <a name="SetDisableRateLimit"></a>
-## func [SetDisableRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L207>)
+## func [SetDisableRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L215>)
 
 ```go
 func SetDisableRateLimit(disable bool)
@@ -476,7 +476,7 @@ func SetDisableRateLimit(disable bool)
 SetDisableRateLimit disables the rate limiting interceptor in the default interceptor chain. Must be called during initialization.
 
 <a name="SetFilterFunc"></a>
-## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L93>)
+## func [SetFilterFunc](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L94>)
 
 ```go
 func SetFilterFunc(ctx context.Context, ff FilterFunc)
@@ -494,7 +494,7 @@ func SetFilterMethods(ctx context.Context, methods []string)
 SetFilterMethods sets the list of method substrings to exclude from tracing/logging. It rebuilds the internal cache. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetProtoValidateOptions"></a>
-## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L165>)
+## func [SetProtoValidateOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L171>)
 
 ```go
 func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error
@@ -504,8 +504,10 @@ SetProtoValidateOptions configures custom protovalidate options \(e.g., custom c
 
 The combined option set \(existing \+ new\) is validated immediately by constructing a protovalidate.Validator. If construction fails, the new options are NOT appended and the error is returned so the caller can surface it \(typically by failing process startup\). Callers that ignore the error keep working with whatever option set was last accepted — the lazy getProtoValidator path still falls back to GlobalValidator on error as a defensive backstop.
 
+On success the cached validator is invalidated so the next getProtoValidator\(\) rebuilds with the updated option set; this matters when SetProtoValidateOptions is called after DefaultInterceptors\(\) has already constructed ProtoValidateInterceptor.
+
 <a name="SetRateLimiter"></a>
-## func [SetRateLimiter](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L213>)
+## func [SetRateLimiter](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L221>)
 
 ```go
 func SetRateLimiter(limiter ratelimit_middleware.Limiter)
@@ -514,7 +516,7 @@ func SetRateLimiter(limiter ratelimit_middleware.Limiter)
 SetRateLimiter sets a custom rate limiter implementation. This overrides the built\-in token bucket limiter. Must be called during initialization.
 
 <a name="SetResponseTimeLogErrorOnly"></a>
-## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L79>)
+## func [SetResponseTimeLogErrorOnly](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L80>)
 
 ```go
 func SetResponseTimeLogErrorOnly(errorOnly bool)
@@ -523,7 +525,7 @@ func SetResponseTimeLogErrorOnly(errorOnly bool)
 SetResponseTimeLogErrorOnly when set to true, only logs response time when the request returns an error. Successful requests are not logged. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetResponseTimeLogLevel"></a>
-## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L72>)
+## func [SetResponseTimeLogLevel](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L73>)
 
 ```go
 func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
@@ -532,7 +534,7 @@ func SetResponseTimeLogLevel(ctx context.Context, level loggers.Level)
 SetResponseTimeLogLevel sets the log level for response time logging. Default is InfoLevel. Must be called during initialization, before the server starts. Not safe for concurrent use.
 
 <a name="SetServerMetricsOptions"></a>
-## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L139>)
+## func [SetServerMetricsOptions](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L140>)
 
 ```go
 func SetServerMetricsOptions(opts ...grpcprom.ServerMetricsOption)
@@ -550,7 +552,7 @@ func TraceIdInterceptor() grpc.UnaryServerInterceptor
 TraceIdInterceptor allows injecting trace id from request objects
 
 <a name="UseColdBrewClientInterceptors"></a>
-## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L133>)
+## func [UseColdBrewClientInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L134>)
 
 ```go
 func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
@@ -559,7 +561,7 @@ func UseColdBrewClientInterceptors(ctx context.Context, flag bool)
 UseColdBrewClientInterceptors allows enabling/disabling coldbrew client interceptors. When set to false, the coldbrew client interceptors will not be used. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="UseColdBrewServerInterceptors"></a>
-## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L114>)
+## func [UseColdBrewServerInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L115>)
 
 ```go
 func UseColdBrewServerInterceptors(ctx context.Context, flag bool)

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"buf.build/go/protovalidate"
@@ -162,6 +163,11 @@ var protovalidateNew = protovalidate.New
 // the error keep working with whatever option set was last accepted —
 // the lazy getProtoValidator path still falls back to GlobalValidator on
 // error as a defensive backstop.
+//
+// On success the cached validator is invalidated so the next
+// getProtoValidator() rebuilds with the updated option set; this matters
+// when SetProtoValidateOptions is called after DefaultInterceptors() has
+// already constructed ProtoValidateInterceptor.
 func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error {
 	candidate := make([]protovalidate.ValidatorOption, 0, len(defaultConfig.protoValidateOpts)+len(opts))
 	candidate = append(candidate, defaultConfig.protoValidateOpts...)
@@ -170,6 +176,8 @@ func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error {
 		return fmt.Errorf("protovalidate options rejected: %w", err)
 	}
 	defaultConfig.protoValidateOpts = candidate
+	protoValidatorOnce = sync.Once{}
+	protoValidatorVal = nil
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -145,11 +146,31 @@ func SetClientMetricsOptions(opts ...grpcprom.ClientMetricsOption) {
 	defaultConfig.cltMetricsOpts = append(defaultConfig.cltMetricsOpts, opts...)
 }
 
+// protovalidateNew is a test seam over protovalidate.New so the error
+// path of SetProtoValidateOptions can be exercised without engineering
+// a real failing option set.
+var protovalidateNew = protovalidate.New
+
 // SetProtoValidateOptions configures custom protovalidate options (e.g.,
 // custom constraints). Must be called during init() — not safe for
 // concurrent use. Follows ColdBrew's init-only config pattern.
-func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) {
-	defaultConfig.protoValidateOpts = append(defaultConfig.protoValidateOpts, opts...)
+//
+// The combined option set (existing + new) is validated immediately by
+// constructing a protovalidate.Validator. If construction fails, the new
+// options are NOT appended and the error is returned so the caller can
+// surface it (typically by failing process startup). Callers that ignore
+// the error keep working with whatever option set was last accepted —
+// the lazy getProtoValidator path still falls back to GlobalValidator on
+// error as a defensive backstop.
+func SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error {
+	candidate := make([]protovalidate.ValidatorOption, 0, len(defaultConfig.protoValidateOpts)+len(opts))
+	candidate = append(candidate, defaultConfig.protoValidateOpts...)
+	candidate = append(candidate, opts...)
+	if _, err := protovalidateNew(candidate...); err != nil {
+		return fmt.Errorf("protovalidate options rejected: %w", err)
+	}
+	defaultConfig.protoValidateOpts = candidate
+	return nil
 }
 
 // SetDisableProtoValidate disables the protovalidate interceptor in the

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -2397,7 +2397,6 @@ func TestRegisterOrReuse_ReusesExisting(t *testing.T) {
 
 func TestSetProtoValidateOptions_Success(t *testing.T) {
 	defer resetGlobals()
-	resetGlobals()
 
 	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
 		t.Fatalf("expected nil error for valid option, got %v", err)
@@ -2409,7 +2408,6 @@ func TestSetProtoValidateOptions_Success(t *testing.T) {
 
 func TestSetProtoValidateOptions_AccumulatesAcrossCalls(t *testing.T) {
 	defer resetGlobals()
-	resetGlobals()
 
 	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
 		t.Fatalf("first call: %v", err)
@@ -2429,7 +2427,6 @@ func TestSetProtoValidateOptions_AccumulatesAcrossCalls(t *testing.T) {
 // the previously-accepted option set rather than silently corrupting state).
 func TestSetProtoValidateOptions_ErrorReturned(t *testing.T) {
 	defer resetGlobals()
-	resetGlobals()
 
 	// Pre-load a valid option so we can verify it survives a later failure.
 	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
@@ -2452,5 +2449,27 @@ func TestSetProtoValidateOptions_ErrorReturned(t *testing.T) {
 	}
 	if got := len(defaultConfig.protoValidateOpts); got != 1 {
 		t.Errorf("rejected option must not be appended; expected 1 stored option (the pre-existing one), got %d", got)
+	}
+}
+
+// TestSetProtoValidateOptions_InvalidatesCache guards against the silent-stale
+// path: if getProtoValidator() ran before a later SetProtoValidateOptions, the
+// cached validator must be rebuilt so the new options actually take effect.
+func TestSetProtoValidateOptions_InvalidatesCache(t *testing.T) {
+	defer resetGlobals()
+
+	// Warm the cache with no options — should yield GlobalValidator.
+	if got := getProtoValidator(); got != protovalidate.GlobalValidator {
+		t.Fatalf("expected GlobalValidator before any options are set, got %T", got)
+	}
+
+	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
+		t.Fatalf("SetProtoValidateOptions: %v", err)
+	}
+
+	// Cache must have been invalidated; the next call rebuilds with the new
+	// option set, producing a non-Global validator.
+	if got := getProtoValidator(); got == protovalidate.GlobalValidator {
+		t.Error("expected getProtoValidator to rebuild after SetProtoValidateOptions; still returning GlobalValidator")
 	}
 }

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"buf.build/go/protovalidate"
 	"github.com/go-coldbrew/errors/notifier"
 	"github.com/go-coldbrew/log"
 	"github.com/go-coldbrew/log/loggers"
@@ -2389,5 +2390,67 @@ func TestRegisterOrReuse_ReusesExisting(t *testing.T) {
 	got := registerOrReuse(second)
 	if got != prometheus.Collector(first) {
 		t.Error("expected registerOrReuse to return the already-registered collector, not the new one")
+	}
+}
+
+// --- SetProtoValidateOptions tests (issue #44) ---
+
+func TestSetProtoValidateOptions_Success(t *testing.T) {
+	defer resetGlobals()
+	resetGlobals()
+
+	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
+		t.Fatalf("expected nil error for valid option, got %v", err)
+	}
+	if got := len(defaultConfig.protoValidateOpts); got != 1 {
+		t.Errorf("expected 1 stored option, got %d", got)
+	}
+}
+
+func TestSetProtoValidateOptions_AccumulatesAcrossCalls(t *testing.T) {
+	defer resetGlobals()
+	resetGlobals()
+
+	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := SetProtoValidateOptions(protovalidate.WithAllowUnknownFields()); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := len(defaultConfig.protoValidateOpts); got != 2 {
+		t.Errorf("expected 2 stored options after two successful calls, got %d", got)
+	}
+}
+
+// TestSetProtoValidateOptions_ErrorReturned guards issue #44: when
+// protovalidate.New rejects the combined option set, SetProtoValidateOptions
+// must return the error and NOT append the rejected options to
+// defaultConfig.protoValidateOpts (so a caller that ignores the error keeps
+// the previously-accepted option set rather than silently corrupting state).
+func TestSetProtoValidateOptions_ErrorReturned(t *testing.T) {
+	defer resetGlobals()
+	resetGlobals()
+
+	// Pre-load a valid option so we can verify it survives a later failure.
+	if err := SetProtoValidateOptions(protovalidate.WithFailFast()); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	sentinel := errors.New("synthetic protovalidate failure")
+	orig := protovalidateNew
+	defer func() { protovalidateNew = orig }()
+	protovalidateNew = func(...protovalidate.ValidatorOption) (protovalidate.Validator, error) {
+		return nil, sentinel
+	}
+
+	err := SetProtoValidateOptions(protovalidate.WithAllowUnknownFields())
+	if err == nil {
+		t.Fatal("expected error from SetProtoValidateOptions when protovalidate.New fails")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+	if got := len(defaultConfig.protoValidateOpts); got != 1 {
+		t.Errorf("rejected option must not be appended; expected 1 stored option (the pre-existing one), got %d", got)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -27,8 +27,12 @@ var (
 	protoValidatorVal  protovalidate.Validator
 )
 
-// getProtoValidator returns a cached protovalidate.Validator configured with
-// custom options if set, falling back to GlobalValidator.
+// getProtoValidator returns a cached protovalidate.Validator configured
+// with the options stored in defaultConfig.protoValidateOpts (validated
+// at SetProtoValidateOptions time), or GlobalValidator when no custom
+// options were supplied. The error path on protovalidate.New is a
+// defensive backstop — under normal use SetProtoValidateOptions has
+// already rejected bad options.
 func getProtoValidator() protovalidate.Validator {
 	protoValidatorOnce.Do(func() {
 		if len(defaultConfig.protoValidateOpts) > 0 {


### PR DESCRIPTION
## Summary

`SetProtoValidateOptions` appended user options blindly. If `protovalidate.New` later failed on those options, the lazy `getProtoValidator` silently fell back to `GlobalValidator` — the caller had no way to know their custom constraints had been dropped. They thought custom validation was active; it wasn't.

Change `SetProtoValidateOptions` to:
1. Build a candidate option set (existing + new).
2. Call `protovalidate.New(candidate...)` eagerly to validate.
3. On error, return a wrapped error and **don't** append the rejected options.
4. On success, commit the new option set.

**Behavior for callers:**
- **Diligent caller** (e.g., `go-coldbrew/core`) propagates the error to its own `Run()` / `main()` so the process refuses to start with bad config — the ideal fail-fast path.
- **Negligent caller** that ignores the error keeps working with the previously-accepted option set; the lazy getter's `GlobalValidator` fallback remains as a defensive backstop. Effective behavior matches today's silent fallback (no regression).

The `getProtoValidator` lazy fallback isn't removed — it's now strictly belt-and-suspenders since `SetProtoValidateOptions` rejects bad opts upfront.

A tiny test seam (`protovalidateNew = protovalidate.New`) lets the test suite exercise the error path without engineering a real failing protovalidate option set (most genuine misconfigs only surface at `Validate` time, not `New` time, so engineering a deterministic `New` failure is awkward).

Fixes #44.

## API change

`SetProtoValidateOptions(opts ...protovalidate.ValidatorOption)` → `SetProtoValidateOptions(opts ...protovalidate.ValidatorOption) error`

Source-compatible — Go allows ignoring returns. Linters that flag unchecked errors will catch existing call sites; that's the point.

## Test plan

- [x] `TestSetProtoValidateOptions_Success` — valid option returns nil and is appended.
- [x] `TestSetProtoValidateOptions_AccumulatesAcrossCalls` — multiple successful calls accumulate.
- [x] `TestSetProtoValidateOptions_ErrorReturned` — synthetic `protovalidate.New` failure causes the error to bubble out wrapped, AND the rejected option is NOT appended (verified to fail on the pre-fix silent-append behavior).
- [x] `go test -race ./...` passes.
- [x] README regenerated via `make doc`.

https://claude.ai/code/session_01EWgytCisKXLiVp5BNhp2xE