### PR TITLE
fix: use govulncheck -scan=module for library CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ doc:
 
 lint:
 	go tool golangci-lint run
-	go tool govulncheck ./...
+	go tool govulncheck -scan=module
 
 bench:
 	go test -run=^$$ -bench=. -benchmem ./...


### PR DESCRIPTION
## Summary

- Use `govulncheck -scan=module` instead of `govulncheck ./...` in CI

Libraries should scan dependencies (go.mod), not stdlib — the stdlib version is the consumer's choice, not the library's. `-scan=module` checks only dependency vulnerabilities, avoiding false failures when the CI Go toolchain has unfixed stdlib CVEs.

## Test plan

- [x] `make lint` passes locally