### PR TITLE
fix: use executor when WithExecutor is set without SetDefaultExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ SetDebugLogHeaderName sets the gRPC metadata header name that triggers per\-requ
 func SetDefaultExecutor(e Executor)
 ```
 
-SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for all outbound unary RPCs. The default client interceptor chain always uses [ExecutorClientInterceptor](<#ExecutorClientInterceptor>); when no executor is configured \(neither global via SetDefaultExecutor nor per\-call via \[WithExecutor\]\), it falls back to [HystrixClientInterceptor](<#HystrixClientInterceptor>) for backward compatibility. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
+SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for outbound unary RPCs when ColdBrew client interceptors are enabled \(the default\). In that configuration, when no executor is configured \(neither global via SetDefaultExecutor nor per\-call via \[WithExecutor\]\), [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) falls back to [HystrixClientInterceptor](<#HystrixClientInterceptor>) for backward compatibility. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDefaultRateLimit"></a>
 ## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L231>)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ func DebugLoggingInterceptor() grpc.UnaryServerInterceptor
 DebugLoggingInterceptor is the interceptor that logs all request/response from a handler
 
 <a name="DefaultClientInterceptor"></a>
-## func [DefaultClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L66>)
+## func [DefaultClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L62>)
 
 ```go
 func DefaultClientInterceptor(defaultOpts ...any) grpc.UnaryClientInterceptor
@@ -174,7 +174,7 @@ func DefaultClientInterceptors(defaultOpts ...any) []grpc.UnaryClientInterceptor
 DefaultClientInterceptors are the set of default interceptors that should be applied to all client calls
 
 <a name="DefaultClientStreamInterceptor"></a>
-## func [DefaultClientStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L71>)
+## func [DefaultClientStreamInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L67>)
 
 ```go
 func DefaultClientStreamInterceptor(defaultOpts ...any) grpc.StreamClientInterceptor
@@ -183,7 +183,7 @@ func DefaultClientStreamInterceptor(defaultOpts ...any) grpc.StreamClientInterce
 DefaultClientStreamInterceptor are the set of default interceptors that should be applied to all stream client calls
 
 <a name="DefaultClientStreamInterceptors"></a>
-## func [DefaultClientStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L51>)
+## func [DefaultClientStreamInterceptors](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L47>)
 
 ```go
 func DefaultClientStreamInterceptors(defaultOpts ...any) []grpc.StreamClientInterceptor
@@ -245,7 +245,7 @@ func (s *svc) echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResp
 ```
 
 <a name="ExecutorClientInterceptor"></a>
-## func [ExecutorClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L114>)
+## func [ExecutorClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L113>)
 
 ```go
 func ExecutorClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientInterceptor
@@ -253,7 +253,7 @@ func ExecutorClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientI
 
 ExecutorClientInterceptor returns a unary client interceptor that wraps each RPC in an [Executor](<#Executor>). The executor provides resilience logic such as circuit breaking, retries, or bulkheading.
 
-If no executor is configured \(neither via [SetDefaultExecutor](<#SetDefaultExecutor>) nor per\-call \[WithExecutor\]\), the RPC is invoked directly as a passthrough.
+Executor resolution order: per\-call \[WithExecutor\] \> global [SetDefaultExecutor](<#SetDefaultExecutor>). When no executor is configured, the interceptor falls back to [HystrixClientInterceptor](<#HystrixClientInterceptor>) for backward compatibility. When the caller explicitly opts out via \[WithoutExecutor\] or \[WithoutHystrix\], the RPC is invoked directly as a passthrough.
 
 Excluded errors and codes \(set via \[WithExcludedErrors\] / \[WithExcludedCodes\]\) are reported as nil to the executor, preventing them from tripping circuit breakers or retry logic. The original error is still returned to the caller.
 
@@ -267,7 +267,7 @@ func FilterMethodsFunc(ctx context.Context, fullMethodName string) bool
 FilterMethodsFunc is the default implementation of Filter function
 
 <a name="GRPCClientInterceptor"></a>
-## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L98>)
+## func [GRPCClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L94>)
 
 ```go
 func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor
@@ -285,7 +285,7 @@ func GetDebugLogHeaderName() string
 GetDebugLogHeaderName returns the current debug log header name.
 
 <a name="HystrixClientInterceptor"></a>
-## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L174>)
+## func [HystrixClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L220>)
 
 ```go
 func HystrixClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientInterceptor
@@ -305,7 +305,7 @@ func NRHttpTracer(pattern string, h http.HandlerFunc) (string, http.HandlerFunc)
 NRHttpTracer wraps an HTTP handler with New Relic tracing. The configured filterFunc \(see SetFilterFunc\) is consulted on every request: paths it rejects run the underlying handler without starting a New Relic transaction. When pattern is non\-empty, newrelic.WrapHandleFunc is used so its route\-level instrumentation stays intact for non\-filtered paths.
 
 <a name="NewRelicClientInterceptor"></a>
-## func [NewRelicClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L78>)
+## func [NewRelicClientInterceptor](<https://github.com/go-coldbrew/interceptors/blob/main/client.go#L74>)
 
 ```go
 func NewRelicClientInterceptor() grpc.UnaryClientInterceptor
@@ -422,13 +422,13 @@ func SetDebugLogHeaderName(name string)
 SetDebugLogHeaderName sets the gRPC metadata header name that triggers per\-request log level override. Default is "x\-debug\-log\-level". The header value should be a valid log level \(e.g., "debug"\). Empty names are ignored. Must be called during initialization.
 
 <a name="SetDefaultExecutor"></a>
-## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L243>)
+## func [SetDefaultExecutor](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L245>)
 
 ```go
 func SetDefaultExecutor(e Executor)
 ```
 
-SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for all outbound unary RPCs. When set, ExecutorClientInterceptor replaces [HystrixClientInterceptor](<#HystrixClientInterceptor>) in the default client interceptor chain. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
+SetDefaultExecutor sets the default [Executor](<#Executor>) used by [ExecutorClientInterceptor](<#ExecutorClientInterceptor>) for all outbound unary RPCs. The default client interceptor chain always uses [ExecutorClientInterceptor](<#ExecutorClientInterceptor>); when no executor is configured \(neither global via SetDefaultExecutor nor per\-call via \[WithExecutor\]\), it falls back to [HystrixClientInterceptor](<#HystrixClientInterceptor>) for backward compatibility. Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 
 <a name="SetDefaultRateLimit"></a>
 ## func [SetDefaultRateLimit](<https://github.com/go-coldbrew/interceptors/blob/main/config.go#L231>)

--- a/client.go
+++ b/client.go
@@ -219,55 +219,21 @@ func hystrixFallback(ctx context.Context, method string, req, reply any, cc *grp
 // See [ExecutorClientInterceptor] for the replacement.
 func HystrixClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		options := clientOptions{
-			hystrixName: method,
-		}
+		o := clientOptions{}
 		for _, opt := range defaultOpts {
 			if opt != nil {
-				if o, ok := opt.(clientOption); ok {
-					o.process(&options)
+				if co, ok := opt.(clientOption); ok {
+					co.process(&o)
 				}
 			}
 		}
 		for _, opt := range opts {
 			if opt != nil {
-				if o, ok := opt.(clientOption); ok {
-					o.process(&options)
+				if co, ok := opt.(clientOption); ok {
+					co.process(&o)
 				}
 			}
 		}
-		if options.disableHystrix {
-			// short circuit if hystrix is disabled
-			return invoker(ctx, method, req, reply, cc, opts...)
-		}
-		newCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		var invokerErr error
-		hystrixErr := hystrix.Do(options.hystrixName, func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = errors.Wrap(fmt.Errorf("panic inside hystrix method: %s, req: %v, reply: %v", method, req, reply), "Hystrix")
-					log.Error(ctx, "panic", r, "method", method, "req", req, "reply", reply)
-				}
-			}()
-			defer notifier.NotifyOnPanic(newCtx, method)
-			invokerErr = invoker(newCtx, method, req, reply, cc, opts...)
-			for _, excludedErr := range options.excludedErrors {
-				if stdError.Is(invokerErr, excludedErr) {
-					return nil
-				}
-			}
-			if st, ok := status.FromError(invokerErr); ok {
-				if slices.Contains(options.excludedCodes, st.Code()) {
-					return nil
-				}
-			}
-			return invokerErr
-		}, nil)
-		if invokerErr != nil {
-			return invokerErr
-		}
-		return hystrixErr
+		return hystrixFallback(ctx, method, req, reply, cc, invoker, opts, o)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -172,8 +172,10 @@ func ExecutorClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientI
 }
 
 // hystrixFallback runs the RPC through the deprecated Hystrix circuit breaker.
-// Called only when no executor is configured (neither global nor per-call),
-// preserving backward compatibility for services that have not migrated.
+// It is the shared Hystrix implementation used both as the executor fallback
+// when no executor is configured (neither global nor per-call) and by
+// [HystrixClientInterceptor], preserving backward compatibility for services
+// that have not migrated.
 func hystrixFallback(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts []grpc.CallOption, o clientOptions) error {
 	if o.disableHystrix {
 		return invoker(ctx, method, req, reply, cc, opts...)

--- a/client.go
+++ b/client.go
@@ -33,11 +33,7 @@ func DefaultClientInterceptors(defaultOpts ...any) []grpc.UnaryClientInterceptor
 				callOptions = append(callOptions, o)
 			}
 		}
-		if defaultConfig.defaultExecutor != nil {
-			ints = append(ints, ExecutorClientInterceptor(callOptions...))
-		} else {
-			ints = append(ints, HystrixClientInterceptor(callOptions...))
-		}
+		ints = append(ints, ExecutorClientInterceptor(callOptions...))
 		ints = append(ints,
 			grpc_retry.UnaryClientInterceptor(),
 			NewRelicClientInterceptor(),
@@ -105,8 +101,11 @@ func GRPCClientInterceptor(_ ...any) grpc.UnaryClientInterceptor {
 // RPC in an [Executor]. The executor provides resilience logic such as circuit
 // breaking, retries, or bulkheading.
 //
-// If no executor is configured (neither via [SetDefaultExecutor] nor per-call
-// [WithExecutor]), the RPC is invoked directly as a passthrough.
+// Executor resolution order: per-call [WithExecutor] > global [SetDefaultExecutor].
+// When no executor is configured, the interceptor falls back to
+// [HystrixClientInterceptor] for backward compatibility. When the caller
+// explicitly opts out via [WithoutExecutor] or [WithoutHystrix], the RPC is
+// invoked directly as a passthrough.
 //
 // Excluded errors and codes (set via [WithExcludedErrors] / [WithExcludedCodes])
 // are reported as nil to the executor, preventing them from tripping circuit
@@ -129,13 +128,18 @@ func ExecutorClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientI
 			}
 		}
 
-		// Resolve executor: per-call > global > nil (passthrough)
+		// Resolve executor: per-call > global > hystrix fallback
 		exec := defaultConfig.defaultExecutor
 		if o.hasExecutor {
 			exec = o.executor
 		}
 		if exec == nil {
-			return invoker(ctx, method, req, reply, cc, opts...)
+			if o.hasExecutor {
+				// Caller explicitly opted out (WithoutExecutor / WithoutHystrix).
+				return invoker(ctx, method, req, reply, cc, opts...)
+			}
+			// No executor configured; fall back to Hystrix for backward compat.
+			return hystrixFallback(ctx, method, req, reply, cc, invoker, opts, o)
 		}
 
 		var invokerErr error
@@ -165,6 +169,48 @@ func ExecutorClientInterceptor(defaultOpts ...grpc.CallOption) grpc.UnaryClientI
 		}
 		return executorErr
 	}
+}
+
+// hystrixFallback runs the RPC through the deprecated Hystrix circuit breaker.
+// Called only when no executor is configured (neither global nor per-call),
+// preserving backward compatibility for services that have not migrated.
+func hystrixFallback(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts []grpc.CallOption, o clientOptions) error {
+	if o.disableHystrix {
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	hystrixCmd := o.hystrixName
+	if hystrixCmd == "" {
+		hystrixCmd = method
+	}
+	newCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var invokerErr error
+	hystrixErr := hystrix.Do(hystrixCmd, func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.Wrap(fmt.Errorf("panic inside hystrix method: %s, req: %v, reply: %v", method, req, reply), "Hystrix")
+				log.Error(ctx, "panic", r, "method", method, "req", req, "reply", reply)
+			}
+		}()
+		defer notifier.NotifyOnPanic(newCtx, method)
+		invokerErr = invoker(newCtx, method, req, reply, cc, opts...)
+		for _, excludedErr := range o.excludedErrors {
+			if stdError.Is(invokerErr, excludedErr) {
+				return nil
+			}
+		}
+		if st, ok := status.FromError(invokerErr); ok {
+			if slices.Contains(o.excludedCodes, st.Code()) {
+				return nil
+			}
+		}
+		return invokerErr
+	}, nil)
+	if invokerErr != nil {
+		return invokerErr
+	}
+	return hystrixErr
 }
 
 // Deprecated: HystrixClientInterceptor wraps the unmaintained hystrix-go library.

--- a/config.go
+++ b/config.go
@@ -237,8 +237,10 @@ func SetDefaultRateLimit(rps float64, burst int) {
 }
 
 // SetDefaultExecutor sets the default [Executor] used by [ExecutorClientInterceptor]
-// for all outbound unary RPCs. When set, ExecutorClientInterceptor replaces
-// [HystrixClientInterceptor] in the default client interceptor chain.
+// for all outbound unary RPCs. The default client interceptor chain always uses
+// [ExecutorClientInterceptor]; when no executor is configured (neither global via
+// SetDefaultExecutor nor per-call via [WithExecutor]), it falls back to
+// [HystrixClientInterceptor] for backward compatibility.
 // Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 func SetDefaultExecutor(e Executor) {
 	defaultConfig.defaultExecutor = e

--- a/config.go
+++ b/config.go
@@ -237,10 +237,10 @@ func SetDefaultRateLimit(rps float64, burst int) {
 }
 
 // SetDefaultExecutor sets the default [Executor] used by [ExecutorClientInterceptor]
-// for all outbound unary RPCs. The default client interceptor chain always uses
-// [ExecutorClientInterceptor]; when no executor is configured (neither global via
-// SetDefaultExecutor nor per-call via [WithExecutor]), it falls back to
-// [HystrixClientInterceptor] for backward compatibility.
+// for outbound unary RPCs when ColdBrew client interceptors are enabled (the
+// default). In that configuration, when no executor is configured (neither global
+// via SetDefaultExecutor nor per-call via [WithExecutor]), [ExecutorClientInterceptor]
+// falls back to [HystrixClientInterceptor] for backward compatibility.
 // Must be called during initialization, before any RPCs are made. Not safe for concurrent use.
 func SetDefaultExecutor(e Executor) {
 	defaultConfig.defaultExecutor = e

--- a/interceptors_test.go
+++ b/interceptors_test.go
@@ -434,7 +434,7 @@ func TestHystrixClientInterceptor(t *testing.T) {
 func TestExecutorClientInterceptor(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("no executor passthrough", func(t *testing.T) {
+	t.Run("no executor falls back to hystrix", func(t *testing.T) {
 		resetGlobals()
 		interceptor := ExecutorClientInterceptor()
 		invokerCalled := false
@@ -509,6 +509,35 @@ func TestExecutorClientInterceptor(t *testing.T) {
 		}
 		if !perCallCalled {
 			t.Error("per-call executor was not called")
+		}
+	})
+
+	t.Run("per-call executor without global executor", func(t *testing.T) {
+		resetGlobals()
+		defer resetGlobals()
+
+		perCallCalled := false
+		perCallExec := func(ctx context.Context, method string, fn func(ctx context.Context) error) error {
+			perCallCalled = true
+			return fn(ctx)
+		}
+
+		interceptor := ExecutorClientInterceptor()
+		invokerCalled := false
+		invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			invokerCalled = true
+			return nil
+		}
+
+		err := interceptor(ctx, "/test/Method", nil, nil, nil, invoker, WithExecutor(perCallExec))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !perCallCalled {
+			t.Error("per-call executor should be used even without global executor")
+		}
+		if !invokerCalled {
+			t.Error("invoker was not called")
 		}
 	})
 
@@ -716,6 +745,102 @@ func TestDefaultClientInterceptors_ExecutorBranching(t *testing.T) {
 		}
 		if !executorCalled {
 			t.Error("executor interceptor should have been used, not hystrix")
+		}
+	})
+
+	t.Run("per-call WithExecutor works without global executor", func(t *testing.T) {
+		resetGlobals()
+		defer resetGlobals()
+
+		perCallCalled := false
+		perCallExec := func(ctx context.Context, method string, fn func(ctx context.Context) error) error {
+			perCallCalled = true
+			return fn(ctx)
+		}
+
+		ints := DefaultClientInterceptors()
+		if len(ints) == 0 {
+			t.Fatal("expected interceptors in default chain")
+		}
+		invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return nil
+		}
+		err := ints[0](context.Background(), "/test/Method", nil, nil, nil, invoker, WithExecutor(perCallExec))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !perCallCalled {
+			t.Error("per-call executor should be used even without global executor")
+		}
+	})
+
+	t.Run("per-connection WithExecutor works without global executor", func(t *testing.T) {
+		resetGlobals()
+		defer resetGlobals()
+
+		connExecCalled := false
+		connExec := func(ctx context.Context, method string, fn func(ctx context.Context) error) error {
+			connExecCalled = true
+			return fn(ctx)
+		}
+
+		ints := DefaultClientInterceptors(WithExecutor(connExec))
+		if len(ints) == 0 {
+			t.Fatal("expected interceptors in default chain")
+		}
+		invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return nil
+		}
+		err := ints[0](context.Background(), "/test/Method", nil, nil, nil, invoker)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !connExecCalled {
+			t.Error("per-connection executor should be used even without global executor")
+		}
+	})
+
+	t.Run("WithoutHystrix passthrough without global executor", func(t *testing.T) {
+		resetGlobals()
+		defer resetGlobals()
+
+		ints := DefaultClientInterceptors()
+		if len(ints) == 0 {
+			t.Fatal("expected interceptors in default chain")
+		}
+		invokerCalled := false
+		invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			invokerCalled = true
+			return nil
+		}
+		err := ints[0](context.Background(), "/test/Method", nil, nil, nil, invoker, WithoutHystrix())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !invokerCalled {
+			t.Error("invoker should be called directly when WithoutHystrix is set")
+		}
+	})
+
+	t.Run("WithoutExecutor passthrough without global executor", func(t *testing.T) {
+		resetGlobals()
+		defer resetGlobals()
+
+		ints := DefaultClientInterceptors()
+		if len(ints) == 0 {
+			t.Fatal("expected interceptors in default chain")
+		}
+		invokerCalled := false
+		invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			invokerCalled = true
+			return nil
+		}
+		err := ints[0](context.Background(), "/test/Method", nil, nil, nil, invoker, WithoutExecutor())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !invokerCalled {
+			t.Error("invoker should be called directly when WithoutExecutor is set")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- `DefaultClientInterceptors` now always uses `ExecutorClientInterceptor` instead of choosing between it and `HystrixClientInterceptor` at construction time
- When no executor is configured (neither global nor per-call), falls back to Hystrix for backward compatibility via `hystrixFallback`
- When `WithExecutor` is passed per-call or per-connection, the executor is used directly — no longer requires `SetDefaultExecutor` to activate the executor code path

## Test plan
- [x] Existing tests pass (`make test` with `-race`)
- [x] New test: per-call `WithExecutor` without global executor
- [x] New test: per-connection `WithExecutor` without global executor
- [x] New test: `WithoutHystrix` passthrough without global executor
- [x] New test: `WithoutExecutor` passthrough without global executor
- [x] `make lint` clean (0 issues)
- [x] `README.md` regenerated via `make doc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation clarifying executor selection precedence and fallback behavior with Hystrix integration.

* **Improvements**
  * Enhanced executor selection logic: per-call configuration takes precedence with consistent Hystrix fallback when no executor is configured.
  * Added explicit opt-out options for executor and Hystrix fallback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->